### PR TITLE
ROS2NodePrintout

### DIFF
--- a/src/main/java/us/ihmc/jros2/ROS2Node.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Node.java
@@ -143,6 +143,8 @@ public class ROS2Node implements Closeable
       participantProfile.setRtps(rtps);
       profilesXML.addParticipantProfile(participantProfile);
 
+      ROS2NodePrintout.print(participantProfile, fastddsTransports);
+
       try
       {
          profilesXML.load();

--- a/src/main/java/us/ihmc/jros2/ROS2NodePrintout.java
+++ b/src/main/java/us/ihmc/jros2/ROS2NodePrintout.java
@@ -15,10 +15,88 @@
  */
 package us.ihmc.jros2;
 
+import jakarta.xml.bind.JAXBElement;
+import us.ihmc.fastddsjava.profiles.gen.ParticipantProfileType;
+import us.ihmc.fastddsjava.profiles.gen.TransportDescriptorType;
+import us.ihmc.log.LogTools;
+
+import java.util.List;
+import java.util.StringJoiner;
+
 class ROS2NodePrintout
 {
    static
    {
       jros2.load();
+   }
+
+   public static void print(ParticipantProfileType participantProfile, TransportDescriptorType... transportDescriptors)
+   {
+      StringJoiner printout = new StringJoiner("\n\t", "\n\t", "");
+
+      // Get the name
+      String nodeName = participantProfile.getRtps().getName();
+      printout.add("Created ROS2Node: %s".formatted(nodeName));
+
+      // Get the domain id and its source
+      int domainId = participantProfile.getDomainId();
+      String domainIdSource = "Constructor Parameter";
+      jros2Settings[] sources = jros2.get().getSettingsSources();
+      for (int i = 0; i < sources.length; ++i)
+      {
+         if (sources[i].hasROSDomainId() && sources[i].rosDomainId() == domainId)
+         {
+            domainIdSource = sources[i].getSourceName();
+            break;
+         }
+      }
+      printout.add("DomainID: %d (As Specified by: %s)".formatted(domainId, domainIdSource));
+
+      boolean usingBuiltinTransports = participantProfile.getRtps().isUseBuiltinTransports();
+      if (usingBuiltinTransports)
+      {
+         printout.add("Using Builtin Transports: UDPv4, SHM");
+      }
+      else
+      {
+         printout.add("Using Custom Transports:");
+
+         if (transportDescriptors != null)
+         {
+            for (int i = 0; i < transportDescriptors.length; ++i)
+            {
+               String type = transportDescriptors[i].getType();
+
+               List<JAXBElement<?>> whitelist = transportDescriptors[i].getInterfaceWhiteList().getAddressOrInterface();
+               if (whitelist.isEmpty())
+               {
+                  printout.add("\t%s: on any interface".formatted(type));
+               }
+               else
+               {
+                  StringJoiner interfaceWhitelist = new StringJoiner(", ");
+                  for (int j = 0; j < whitelist.size(); ++j)
+                  {
+                     Object value = whitelist.get(i).getValue();
+                     if (value instanceof List<?> list)
+                     {
+                        for (int k = 0; k < list.size(); ++k)
+                        {
+                           interfaceWhitelist.add(list.get(i).toString());
+                        }
+                     }
+                     else if (value instanceof String string)
+                     {
+                        interfaceWhitelist.add(string);
+                     }
+                  }
+
+                  printout.add("\t%s: on %s".formatted(type, interfaceWhitelist));
+               }
+            }
+         }
+      }
+
+      LogTools.info(printout);
    }
 }

--- a/src/main/java/us/ihmc/jros2/jros2.java
+++ b/src/main/java/us/ihmc/jros2/jros2.java
@@ -19,6 +19,7 @@ import us.ihmc.fastddsjava.library.fastddsjavaNativeLibrary;
 
 final class jros2 implements jros2Settings
 {
+   private static final String SOURCE_NAME = "jros2.java";
    private static jros2 instance;
 
    /**
@@ -73,6 +74,12 @@ final class jros2 implements jros2Settings
    boolean isLoaded()
    {
       return loaded;
+   }
+
+   @Override
+   public String getSourceName()
+   {
+      return SOURCE_NAME;
    }
 
    @Override
@@ -135,5 +142,10 @@ final class jros2 implements jros2Settings
       }
 
       return false;
+   }
+
+   public jros2Settings[] getSettingsSources()
+   {
+      return settingsSources;
    }
 }

--- a/src/main/java/us/ihmc/jros2/jros2Settings.java
+++ b/src/main/java/us/ihmc/jros2/jros2Settings.java
@@ -17,6 +17,8 @@ package us.ihmc.jros2;
 
 interface jros2Settings
 {
+   String getSourceName();
+
    /**
     * The default domain ID jros2 will use when constructing new {@link ROS2Node}.
     * See: <a href="https://docs.ros.org/en/humble/Concepts/Intermediate/About-Domain-ID.html#the-ros-domain-id">ROS 2 Domain ID</a>.

--- a/src/main/java/us/ihmc/jros2/jros2SettingsDefault.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsDefault.java
@@ -17,6 +17,14 @@ package us.ihmc.jros2;
 
 class jros2SettingsDefault implements jros2Settings
 {
+   private static final String NAME = "Default Values";
+
+   @Override
+   public String getSourceName()
+   {
+      return NAME;
+   }
+
    @Override
    public int rosDomainId()
    {

--- a/src/main/java/us/ihmc/jros2/jros2SettingsEnv.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsEnv.java
@@ -22,6 +22,8 @@ import java.util.Map;
  */
 class jros2SettingsEnv implements jros2Settings
 {
+   private static final String SOURCE_NAME = "Environment Variables";
+
    static final String DOMAIN_ID_KEY = "ROS_DOMAIN_ID";
    static final String INTERFACE_WHITELIST_KEY = "FASTDDS_INTERFACE_WHITELIST";
 
@@ -40,6 +42,12 @@ class jros2SettingsEnv implements jros2Settings
    jros2SettingsEnv(Map<String, String> env)
    {
       this.env = env;
+   }
+
+   @Override
+   public String getSourceName()
+   {
+      return SOURCE_NAME;
    }
 
    @Override

--- a/src/main/java/us/ihmc/jros2/jros2SettingsFile.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsFile.java
@@ -30,6 +30,8 @@ import java.util.Properties;
  */
 class jros2SettingsFile implements jros2Settings
 {
+   private static final String SOURCE_NAME = "jros2.properties";
+
    static final String DOMAIN_ID_KEY = "jros2.ros.domain.id";
    static final String INTERFACE_WHITELIST_KEY = "jros2.fastdds.interface.whitelist";
 
@@ -147,6 +149,12 @@ class jros2SettingsFile implements jros2Settings
             LogTools.warn("Found RTPSDomainID in {}, but failed to parse the value ({}).", compatibilityFilePath.getFileName(), rtpsDomainId);
          }
       }
+   }
+
+   @Override
+   public String getSourceName()
+   {
+      return SOURCE_NAME;
    }
 
    @Override

--- a/src/main/java/us/ihmc/jros2/jros2SettingsProp.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsProp.java
@@ -20,8 +20,16 @@ package us.ihmc.jros2;
  */
 class jros2SettingsProp implements jros2Settings
 {
+   private static final String SOURCE_NAME = "System Properties";
+
    static final String DOMAIN_ID_KEY = "ros.domain.id";
    static final String INTERFACE_WHITELIST_KEY = "fastdds.interface.whitelist";
+
+   @Override
+   public String getSourceName()
+   {
+      return SOURCE_NAME;
+   }
 
    @Override
    public int rosDomainId()


### PR DESCRIPTION
Printout looks something like this: 
```
250609 12:25:11:769 [INFO] (ROS2NodePrintout.java:102): 
	Created ROS2Node: test_node
	DomainID: 219 (As Specified by: jros2.properties)
	Using Builtin Transports: UDPv4, SHM
```
```
250609 12:22:22:371 [INFO] (ROS2NodePrintout.java:102): 
	Created ROS2Node: test_node
	DomainID: 218 (As Specified by: Constructor Parameter)
	Using Custom Transports:
		SHM: on any interface
		TCPv4: on lo, 192.0.2.0
```

Not including whether intra-process comms are enabled since it's a library setting, not a node setting. 

Source of the domain id is simply searched for, and can be inaccurate. E.g. if the user programmatically passes in the same domain id as specified in jros2.properties, it'll think it's from jros2.properties. Not sure how to improve that. 

The interface whitelist is per transport, so I list the interfaces after each custom transport. Maybe I should do the same with the builtin ones for consistency (though it'd be just "on any interface" for both of them)?