### PR TITLE
Add argument to ROS2Node constructor for intraprocess delivery

### DIFF
--- a/src/main/java/us/ihmc/fastddsjava/profiles/ProfilesXML.java
+++ b/src/main/java/us/ihmc/fastddsjava/profiles/ProfilesXML.java
@@ -53,8 +53,6 @@ public class ProfilesXML
       librarySettingsType = new LibrarySettingsType();
       logType = new LogType();
       typesType = new TypesType();
-
-      librarySettingsType.setIntraprocessDelivery("FULL"); // Default to enable Intraprocess delivery
    }
 
    public void load() throws fastddsjavaException
@@ -87,6 +85,11 @@ public class ProfilesXML
    public TypesType getTypesType()
    {
       return typesType;
+   }
+
+   public void enableIntraprocess(boolean intraprocess)
+   {
+      librarySettingsType.setIntraprocessDelivery(intraprocess ? "FULL" : "OFF");
    }
 
    public void addParticipantProfile(ParticipantProfileType participantProfileType)

--- a/src/main/java/us/ihmc/jros2/AsyncROS2Node.java
+++ b/src/main/java/us/ihmc/jros2/AsyncROS2Node.java
@@ -42,19 +42,9 @@ public class AsyncROS2Node extends ROS2Node
    private final Thread publishThread;
    private final BlockingQueue<Runnable> tasks;
 
-   public AsyncROS2Node(String name)
+   public AsyncROS2Node(String name, int domainId, boolean fastddsIntraprocessDelivery, TransportDescriptorType... fastddsTransports)
    {
-      this(name, jros2.get().rosDomainId());
-   }
-
-   public AsyncROS2Node(String name, int domainId)
-   {
-      this(name, domainId, (TransportDescriptorType[]) null);
-   }
-
-   public AsyncROS2Node(String name, int domainId, TransportDescriptorType... fastddsTransports)
-   {
-      super(name, domainId, fastddsTransports);
+      super(name, domainId, fastddsIntraprocessDelivery, fastddsTransports);
 
       int capacity = 64;
 
@@ -62,6 +52,16 @@ public class AsyncROS2Node extends ROS2Node
       tasks = new ArrayBlockingQueue<>(capacity, true);
       publishThread = new Thread(this::publishLoop);
       publishThread.start();
+   }
+
+   public AsyncROS2Node(String name, int domainId)
+   {
+      this(name, domainId, false, (TransportDescriptorType[]) null);
+   }
+
+   public AsyncROS2Node(String name)
+   {
+      this(name, jros2.get().rosDomainId());
    }
 
    @Override

--- a/src/main/java/us/ihmc/jros2/ROS2Node.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Node.java
@@ -98,7 +98,18 @@ public class ROS2Node implements Closeable
    protected final ReadWriteLock closeLock;
    protected boolean closed;
 
-   public ROS2Node(String name, int domainId, TransportDescriptorType... fastddsTransports)
+   /**
+    * Create a new ROS 2 Node for managing ROS 2-compatible publishers, subscriptions.
+    * @param name The colloquial name for the node, not used internally.
+    * @param domainId The domain ID the node will use when writing and reading to the network transport.
+    * @param fastddsIntraprocessDelivery true if intraprocess delivery should be enabled. Using intraprocess delivery means publishers will directly
+    *                                    call the receive-method of subscriptions. Please note that any operations the subscriptions perform in
+    *                                    the {@link ROS2SubscriptionReader} will block the publish method of the {@link ROS2Publisher}. Do not enable
+    *                                    in performance critical loops without using {@link AsyncROS2Publisher}.
+    * @param fastddsTransports An optional list of Transports to enable. These define what network protocol and network parameters to use when communicating
+    *                          over the network. See: {@link TransportDescriptorTypeTools}.
+    */
+   public ROS2Node(String name, int domainId, boolean fastddsIntraprocessDelivery, TransportDescriptorType... fastddsTransports)
    {
       if (name == null)
       {
@@ -113,6 +124,8 @@ public class ROS2Node implements Closeable
       this.domainId = domainId;
 
       ProfilesXML profilesXML = new ProfilesXML();
+
+      profilesXML.enableIntraprocess(fastddsIntraprocessDelivery);
 
       ParticipantProfileType participantProfile = new ParticipantProfileType();
       String participantProfileName = UUID.randomUUID().toString();
@@ -141,37 +154,7 @@ public class ROS2Node implements Closeable
          rtps.setUserTransports(userTransports);
       }
 
-      /*
-       * Check if SHM is usable on Windows (sometimes the SHM directory can lose write permissions)
-       */
-      if (System.getProperty("os.name").startsWith("Windows") && !TransportDescriptorTypeTools.SHM_TRANSPORT_AVAILABLE_ON_WINDOWS)
-      {
-         boolean shmEnabled = false;
-
-         if (rtps.isUseBuiltinTransports())
-         {
-            shmEnabled = true;
-         }
-         else if (fastddsTransports != null)
-         {
-            for (int i = 0; i < fastddsTransports.length; ++i)
-            {
-               TransportDescriptorType transportDescriptorType = fastddsTransports[i];
-
-               if (transportDescriptorType.getType().equals("SHM"))
-               {
-                  shmEnabled = true;
-                  break;
-               }
-            }
-         }
-
-         if (shmEnabled)
-         {
-            LogTools.error("Shared Memory Transport (SHM) is not available. Could not write to: C:\\ProgramData\\eprosima\\fastdds_interprocess");
-            LogTools.error("Try restarting the process after deleting the directory.");
-         }
-      }
+      checkSHMAvailabilityWindows(rtps, fastddsTransports);
 
       participantProfile.setRtps(rtps);
       profilesXML.addParticipantProfile(participantProfile);
@@ -203,7 +186,7 @@ public class ROS2Node implements Closeable
 
    public ROS2Node(String name, int domainId)
    {
-      this(name, domainId, (TransportDescriptorType[]) null);
+      this(name, domainId, false, (TransportDescriptorType[]) null);
    }
 
    protected <T extends ROS2Message<T>> TopicData getOrCreateTopicData(ROS2Topic<T> topic)
@@ -509,6 +492,41 @@ public class ROS2Node implements Closeable
 
          // Delete participant
          retcodePrintOnError(fastddsjava_delete_participant(fastddsParticipant));
+      }
+   }
+
+   /**
+    * Check if SHM is usable on Windows (sometimes the SHM directory can lose write permissions)
+    */
+   private static void checkSHMAvailabilityWindows(Rtps rtps, TransportDescriptorType... fastddsTransports)
+   {
+      if (System.getProperty("os.name").startsWith("Windows") && !TransportDescriptorTypeTools.SHM_TRANSPORT_AVAILABLE_ON_WINDOWS)
+      {
+         boolean shmEnabled = false;
+
+         if (rtps.isUseBuiltinTransports())
+         {
+            shmEnabled = true;
+         }
+         else if (fastddsTransports != null)
+         {
+            for (int i = 0; i < fastddsTransports.length; ++i)
+            {
+               TransportDescriptorType transportDescriptorType = fastddsTransports[i];
+
+               if (transportDescriptorType.getType().equals("SHM"))
+               {
+                  shmEnabled = true;
+                  break;
+               }
+            }
+         }
+
+         if (shmEnabled)
+         {
+            LogTools.error("Shared Memory Transport (SHM) is not available. Could not write to: C:\\ProgramData\\eprosima\\fastdds_interprocess");
+            LogTools.error("Try restarting the process after deleting the directory.");
+         }
       }
    }
 }


### PR DESCRIPTION
We default to intraprocess delivery = OFF, I think it's best to avoid unexpected performance issues if there is considerable logic in subscription readers and the user isn't using AsyncROS2Node/Publisher. Open to opinions on this. 