### PR TITLE
Add jros2 setting for intraprocess delivery

### DIFF
--- a/src/main/java/us/ihmc/fastddsjava/profiles/ProfilesXML.java
+++ b/src/main/java/us/ihmc/fastddsjava/profiles/ProfilesXML.java
@@ -41,6 +41,22 @@ public class ProfilesXML
 {
    public static final String FAST_DDS_NAMESPACE_URI = "http://www.eprosima.com";
    private static final Object loadLock = new Object();
+   private static String intraprocessDelivery;
+
+   public static void setIntraprocessDelivery(String value)
+   {
+      switch (value)
+      {
+         case "OFF":
+         case "USER_DATA_ONLY":
+         case "FULL":
+            break;
+         default:
+            throw new IllegalArgumentException("Invalid intraprocess delivery mode: " + value);
+      }
+
+      intraprocessDelivery = value;
+   }
 
    private final ProfilesType profilesType;
    private final LibrarySettingsType librarySettingsType;
@@ -54,7 +70,7 @@ public class ProfilesXML
       logType = new LogType();
       typesType = new TypesType();
 
-      librarySettingsType.setIntraprocessDelivery("FULL"); // Default to enable Intraprocess delivery
+      librarySettingsType.setIntraprocessDelivery(intraprocessDelivery);
    }
 
    public void load() throws fastddsjavaException

--- a/src/main/java/us/ihmc/jros2/jros2.java
+++ b/src/main/java/us/ihmc/jros2/jros2.java
@@ -16,6 +16,7 @@
 package us.ihmc.jros2;
 
 import us.ihmc.fastddsjava.library.fastddsjavaNativeLibrary;
+import us.ihmc.fastddsjava.profiles.ProfilesXML;
 
 final class jros2 implements jros2Settings
 {
@@ -37,6 +38,21 @@ final class jros2 implements jros2Settings
    private jros2()
    {
       this(new jros2Settings[] {new jros2SettingsProp(), new jros2SettingsEnv(), new jros2SettingsFile(), new jros2SettingsDefault()});
+
+      /*
+       * Intraprocess delivery mode can only be set once per jros2 instance, not per-node. Consider the following scenario:
+       *
+       *   1. Create node A with intraprocess OFF
+       *   2. Create node B with intraprocess ON
+       *   3. Create publisher using node A
+       *
+       *   You may expect the publisher to not use intraprocess, but it's most likely that it will because node B has enabled intraprocess for the entire
+       *   Fast-DDS library instance.
+       *
+       * See: https://fast-dds.docs.eprosima.com/en/v3.2.2/fastdds/xml_configuration/library_settings.html#intra-process-delivery-xml-profile
+       * Notice how intraprocess delivery is a library setting, not a participant, data reader, or data writer setting.
+       */
+      ProfilesXML.setIntraprocessDelivery(intraprocessDelivery() ? "FULL" : "OFF");
    }
 
    /**
@@ -105,6 +121,37 @@ final class jros2 implements jros2Settings
       for (int i = 0; i < settingsSources.length; ++i)
       {
          if (settingsSources[i].hasROSDomainId())
+         {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   @Override
+   public boolean intraprocessDelivery()
+   {
+      // Loop through setting sources in order of priority
+      for (int i = 0; i < settingsSources.length; ++i)
+      {
+         // If the source specifies intraprocess delivery, return the value
+         if (settingsSources[i].hasIntraprocessDelivery())
+         {
+            return settingsSources[i].intraprocessDelivery();
+         }
+      }
+
+      // Realistically should never reach here
+      return settingsSources[settingsSources.length - 1].intraprocessDelivery();
+   }
+
+   @Override
+   public boolean hasIntraprocessDelivery()
+   {
+      for (int i = 0; i < settingsSources.length; ++i)
+      {
+         if (settingsSources[i].hasIntraprocessDelivery())
          {
             return true;
          }

--- a/src/main/java/us/ihmc/jros2/jros2Settings.java
+++ b/src/main/java/us/ihmc/jros2/jros2Settings.java
@@ -31,6 +31,20 @@ interface jros2Settings
    boolean hasROSDomainId();
 
    /**
+    * @return true if intraprocess delivery should be enabled. Using intraprocess delivery means publishers will directly
+    *       call the receive-method of subscriptions. Please note that any operations the subscriptions perform in
+    *       the {@link ROS2SubscriptionReader} will block the publish method of the {@link ROS2Publisher}. Do not enable
+    *       in performance critical loops without using {@link AsyncROS2Publisher}.
+    *       See: <a href="https://fast-dds.docs.eprosima.com/en/v3.2.2/fastdds/transport/intraprocess.html">Intra-process delivery</a>
+    */
+   boolean intraprocessDelivery();
+
+   /**
+    * @return Whether enabling Fast-DDS intraprocess delivery has been specified.
+    */
+   boolean hasIntraprocessDelivery();
+
+   /**
     * A list of addresses (IPv4 or IPv6) and/or interface names which correspond to network interfaces on the host system.
     * {@link ROS2Node} will only be able to communicate using whitelisted network interfaces.
     * Empty or null for no whitelist.

--- a/src/main/java/us/ihmc/jros2/jros2SettingsDefault.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsDefault.java
@@ -38,6 +38,18 @@ class jros2SettingsDefault implements jros2Settings
    }
 
    @Override
+   public boolean intraprocessDelivery()
+   {
+      return false;
+   }
+
+   @Override
+   public boolean hasIntraprocessDelivery()
+   {
+      return true;
+   }
+
+   @Override
    public String[] interfaceWhitelist()
    {
       return new String[0];

--- a/src/main/java/us/ihmc/jros2/jros2SettingsEnv.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsEnv.java
@@ -25,6 +25,7 @@ class jros2SettingsEnv implements jros2Settings
    private static final String SOURCE_NAME = "Environment Variables";
 
    static final String DOMAIN_ID_KEY = "ROS_DOMAIN_ID";
+   static final String INTRAPROCESS_DELIVERY_KEY = "FASTDDS_INRAPROCESS_DELIVERY";
    static final String INTERFACE_WHITELIST_KEY = "FASTDDS_INTERFACE_WHITELIST";
 
    private final Map<String, String> env;
@@ -67,6 +68,18 @@ class jros2SettingsEnv implements jros2Settings
    public boolean hasROSDomainId()
    {
       return env.containsKey(DOMAIN_ID_KEY);
+   }
+
+   @Override
+   public boolean intraprocessDelivery()
+   {
+      return env.getOrDefault(INTRAPROCESS_DELIVERY_KEY, Boolean.toString(new jros2SettingsDefault().intraprocessDelivery())).equalsIgnoreCase("true");
+   }
+
+   @Override
+   public boolean hasIntraprocessDelivery()
+   {
+      return env.containsKey(INTRAPROCESS_DELIVERY_KEY);
    }
 
    @Override

--- a/src/main/java/us/ihmc/jros2/jros2SettingsFile.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsFile.java
@@ -33,6 +33,7 @@ class jros2SettingsFile implements jros2Settings
    private static final String SOURCE_NAME = "jros2.properties";
 
    static final String DOMAIN_ID_KEY = "jros2.ros.domain.id";
+   static final String INTRAPROCESS_DELIVERY_KEY = "jros2.fastdds.intraprocess.delivery";
    static final String INTERFACE_WHITELIST_KEY = "jros2.fastdds.interface.whitelist";
 
    private static final Path DEFAULT_FILE_PATH = Path.of(System.getProperty("user.home"), ".ihmc", "jros2.properties");
@@ -42,6 +43,7 @@ class jros2SettingsFile implements jros2Settings
    private final Path filePath;
    private final Path compatibilityFilePath;
    private int rosDomainId;
+   private boolean intraprocessDelivery;
    private String[] interfaceWhitelist;
 
    jros2SettingsFile()
@@ -55,6 +57,7 @@ class jros2SettingsFile implements jros2Settings
       this.compatibilityFilePath = compatibilityFilePath;
 
       rosDomainId = DEFAULTS.rosDomainId();
+      intraprocessDelivery = DEFAULTS.intraprocessDelivery();
       interfaceWhitelist = DEFAULTS.interfaceWhitelist();
 
       try
@@ -87,6 +90,7 @@ class jros2SettingsFile implements jros2Settings
 
       Properties properties = new Properties();
       properties.setProperty(DOMAIN_ID_KEY, String.valueOf(rosDomainId));
+      properties.setProperty(INTRAPROCESS_DELIVERY_KEY, String.valueOf(intraprocessDelivery));
       properties.setProperty(INTERFACE_WHITELIST_KEY, String.join(", ", interfaceWhitelist));
 
       try (FileOutputStream output = new FileOutputStream(file))
@@ -116,6 +120,7 @@ class jros2SettingsFile implements jros2Settings
       try
       {
          rosDomainId = Integer.parseInt(properties.getProperty(DOMAIN_ID_KEY));
+         intraprocessDelivery = Boolean.parseBoolean(properties.getProperty(INTRAPROCESS_DELIVERY_KEY));
          interfaceWhitelist = jros2Settings.splitInterfaceWhitelistFromCSV(properties.getProperty(INTERFACE_WHITELIST_KEY));
       }
       catch (Exception e)
@@ -167,6 +172,18 @@ class jros2SettingsFile implements jros2Settings
    public boolean hasROSDomainId()
    {
       return DEFAULTS.rosDomainId() != rosDomainId;
+   }
+
+   @Override
+   public boolean intraprocessDelivery()
+   {
+      return intraprocessDelivery;
+   }
+
+   @Override
+   public boolean hasIntraprocessDelivery()
+   {
+      return DEFAULTS.intraprocessDelivery() != intraprocessDelivery;
    }
 
    @Override

--- a/src/main/java/us/ihmc/jros2/jros2SettingsProp.java
+++ b/src/main/java/us/ihmc/jros2/jros2SettingsProp.java
@@ -23,6 +23,7 @@ class jros2SettingsProp implements jros2Settings
    private static final String SOURCE_NAME = "System Properties";
 
    static final String DOMAIN_ID_KEY = "ros.domain.id";
+   static final String INTRAPROCESS_DELIVERY_KEY = "fastdds.intraprocess.delivery";
    static final String INTERFACE_WHITELIST_KEY = "fastdds.interface.whitelist";
 
    @Override
@@ -48,6 +49,21 @@ class jros2SettingsProp implements jros2Settings
    public boolean hasROSDomainId()
    {
       return System.getProperties().containsKey(DOMAIN_ID_KEY);
+   }
+
+   @Override
+   public boolean intraprocessDelivery()
+   {
+      return System.getProperties()
+                   .getOrDefault(INTRAPROCESS_DELIVERY_KEY, Boolean.toString(new jros2SettingsDefault().intraprocessDelivery()))
+                   .toString()
+                   .equalsIgnoreCase("true");
+   }
+
+   @Override
+   public boolean hasIntraprocessDelivery()
+   {
+      return System.getProperties().containsKey(INTRAPROCESS_DELIVERY_KEY);
    }
 
    @Override

--- a/src/test/java/us/ihmc/jros2/jros2SettingsTest.java
+++ b/src/test/java/us/ihmc/jros2/jros2SettingsTest.java
@@ -34,6 +34,10 @@ public class jros2SettingsTest
       final int environmentDomainId = 112;
       final int fileDomainId = 113;
 
+      final boolean systemIntraprocessDelivery = false;
+      final boolean environmentIntraprocessDelivery = true;
+      final boolean fileIntraprocessDelivery = false;
+
       final String[] systemPropertyInterfaceWhitelist = {"192.0.2.1"};
       final String[] environmentInterfaceWhitelist = {"192.0.2.2", "127.0.0.1"};
       final String[] fileInterfaceWhitelist = {"192.0.2.3", "127.0.0.1", "0.0.0.0"};
@@ -76,11 +80,13 @@ public class jros2SettingsTest
                   if (systemPropertiesHaveValues)
                   {
                      System.setProperty(jros2SettingsProp.DOMAIN_ID_KEY, Integer.toString(systemPropertyDomainId));
+                     System.setProperty(jros2SettingsProp.INTRAPROCESS_DELIVERY_KEY, Boolean.toString(systemIntraprocessDelivery));
                      System.setProperty(jros2SettingsProp.INTERFACE_WHITELIST_KEY, systemPropertyInterfaceWhitelist[0]);
                   }
                   else // Otherwise ensure system does not have jros2 related properties
                   {
                      System.clearProperty(jros2SettingsProp.DOMAIN_ID_KEY);
+                     System.clearProperty(jros2SettingsProp.INTRAPROCESS_DELIVERY_KEY);
                      System.clearProperty(jros2SettingsProp.INTERFACE_WHITELIST_KEY);
                   }
 
@@ -104,6 +110,7 @@ public class jros2SettingsTest
                   if ((hasValuesPermutation & environmentSettingsMask) != 0)
                   {
                      environment.put(jros2SettingsEnv.DOMAIN_ID_KEY, String.valueOf(environmentDomainId));
+                     environment.put(jros2SettingsEnv.INTRAPROCESS_DELIVERY_KEY, String.valueOf(environmentIntraprocessDelivery));
                      environment.put(jros2SettingsEnv.INTERFACE_WHITELIST_KEY, environmentInterfaceWhitelist[0]);
                   }
 
@@ -131,6 +138,7 @@ public class jros2SettingsTest
                      // Write the properties to the properties file
                      Properties properties = new Properties();
                      properties.setProperty(jros2SettingsFile.DOMAIN_ID_KEY, String.valueOf(fileDomainId));
+                     properties.setProperty(jros2SettingsFile.INTRAPROCESS_DELIVERY_KEY, String.valueOf(fileIntraprocessDelivery));
                      properties.setProperty(jros2SettingsFile.INTERFACE_WHITELIST_KEY, fileInterfaceWhitelist[0]);
                      try (FileOutputStream output = new FileOutputStream(fakeFile))
                      {
@@ -155,15 +163,22 @@ public class jros2SettingsTest
 
                // The instance should always have values, since the default settings are always added
                assertTrue(instance.hasROSDomainId());
+               assertTrue(instance.hasIntraprocessDelivery());
                assertTrue(instance.hasInterfaceWhitelist());
 
                // Ensure the jros2 instance settings values match the highest priority settings that has values.
                for (jros2Settings settings : settingsList)
                {
-                  boolean hasValues = settings.hasROSDomainId() && settings.hasInterfaceWhitelist();
+                  if (settings instanceof jros2SettingsDefault)
+                  {
+                     continue;
+                  }
+
+                  boolean hasValues = settings.hasROSDomainId() && settings.hasIntraprocessDelivery() && settings.hasInterfaceWhitelist();
                   if (hasValues)
                   {
                      assertEquals(settings.rosDomainId(), instance.rosDomainId());
+                     assertEquals(settings.intraprocessDelivery(), instance.intraprocessDelivery());
                      assertEquals(settings.interfaceWhitelist().length, instance.interfaceWhitelist().length);
                      for (int i = 0; i < settings.interfaceWhitelist().length; ++i)
                      {
@@ -193,6 +208,7 @@ public class jros2SettingsTest
    {
       jros2Settings defaultSettings = new jros2SettingsDefault();
       assertTrue(defaultSettings.hasROSDomainId());
+      assertTrue(defaultSettings.hasIntraprocessDelivery());
       assertTrue(defaultSettings.hasInterfaceWhitelist());
       assertEquals(0, defaultSettings.rosDomainId());
       assertEquals(0, defaultSettings.interfaceWhitelist().length);
@@ -225,6 +241,7 @@ public class jros2SettingsTest
          // Values should match default values
          jros2Settings defaultSettings = new jros2SettingsDefault();
          assertEquals(defaultSettings.rosDomainId(), fileSettings.rosDomainId());
+         assertEquals(defaultSettings.intraprocessDelivery(), fileSettings.intraprocessDelivery());
          assertEquals(defaultSettings.interfaceWhitelist().length, fileSettings.interfaceWhitelist().length);
       }
       finally
@@ -255,6 +272,7 @@ public class jros2SettingsTest
 
          // Put property values
          int domainId = 113;
+         boolean intraprocessDelivery = true;
          String[] interfaceWhitelist = {"127.0.0.1", "192.0.2.1"};
 
          StringJoiner csvWhitelist = new StringJoiner(", ");
@@ -263,6 +281,7 @@ public class jros2SettingsTest
 
          Properties properties = new Properties();
          properties.setProperty(jros2SettingsFile.DOMAIN_ID_KEY, String.valueOf(domainId));
+         properties.setProperty(jros2SettingsFile.INTRAPROCESS_DELIVERY_KEY, Boolean.toString(intraprocessDelivery));
          properties.setProperty(jros2SettingsFile.INTERFACE_WHITELIST_KEY, csvWhitelist.toString());
          try (FileOutputStream output = new FileOutputStream(fakeFile))
          {
@@ -272,6 +291,7 @@ public class jros2SettingsTest
          jros2Settings fileSettings = new jros2SettingsFile(fakeFilePath, fakeCompatibilityFilePath);
 
          assertTrue(fileSettings.hasROSDomainId());
+         assertTrue(fileSettings.hasIntraprocessDelivery());
          assertTrue(fileSettings.hasInterfaceWhitelist());
 
          // Ensure values are correct
@@ -420,25 +440,34 @@ public class jros2SettingsTest
 
       // No environment variables defined. Should say it doesn't have values
       assertFalse(environmentSettings.hasROSDomainId());
+      assertFalse(environmentSettings.hasIntraprocessDelivery());
       assertFalse(environmentSettings.hasInterfaceWhitelist());
 
       // No environment variables defined. Should return default values
       assertEquals(defaultSettings.rosDomainId(), environmentSettings.rosDomainId());
+      assertEquals(defaultSettings.intraprocessDelivery(), environmentSettings.intraprocessDelivery());
       assertEquals(defaultSettings.interfaceWhitelist().length, environmentSettings.interfaceWhitelist().length);
 
       //// ENVIRONMENT WITH VALUES DEFINED ////
       int domainId = 113;
+      boolean intraprocessDelivery = false;
       String[] interfaceWhitelist = {"127.0.0.1", "192.0.2.1"};
 
       StringJoiner csvWhitelist = new StringJoiner(", ");
       for (String intrface : interfaceWhitelist)
          csvWhitelist.add(intrface);
 
-      environment = Map.of(jros2SettingsEnv.DOMAIN_ID_KEY, String.valueOf(domainId), jros2SettingsEnv.INTERFACE_WHITELIST_KEY, csvWhitelist.toString());
+      environment = Map.of(jros2SettingsEnv.DOMAIN_ID_KEY,
+                           String.valueOf(domainId),
+                           jros2SettingsEnv.INTRAPROCESS_DELIVERY_KEY,
+                           String.valueOf(intraprocessDelivery),
+                           jros2SettingsEnv.INTERFACE_WHITELIST_KEY,
+                           csvWhitelist.toString());
       environmentSettings = new jros2SettingsEnv(environment);
 
       // Should report that it has values
       assertTrue(environmentSettings.hasROSDomainId());
+      assertTrue(environmentSettings.hasIntraprocessDelivery());
       assertTrue(environmentSettings.hasInterfaceWhitelist());
 
       // Now the values should reflect the newly defined system properties
@@ -454,6 +483,7 @@ public class jros2SettingsTest
    {
       // Ensure no properties have been set
       System.clearProperty(jros2SettingsProp.DOMAIN_ID_KEY);
+      System.clearProperty(jros2SettingsProp.INTRAPROCESS_DELIVERY_KEY);
       System.clearProperty(jros2SettingsProp.INTERFACE_WHITELIST_KEY);
 
       jros2Settings defaultSettings = new jros2SettingsDefault();
@@ -461,13 +491,16 @@ public class jros2SettingsTest
 
       // Should say that it doesn't have values
       assertFalse(systemPropertySettings.hasROSDomainId());
+      assertFalse(systemPropertySettings.hasIntraprocessDelivery());
       assertFalse(systemPropertySettings.hasInterfaceWhitelist());
 
       // No system properties defined. Should return default values
       assertEquals(defaultSettings.rosDomainId(), systemPropertySettings.rosDomainId());
+      assertEquals(defaultSettings.intraprocessDelivery(), systemPropertySettings.intraprocessDelivery());
       assertEquals(defaultSettings.interfaceWhitelist().length, systemPropertySettings.interfaceWhitelist().length);
 
       int domainId = 113;
+      boolean intraprocessDelivery = false;
       String[] interfaceWhitelist = {"127.0.0.1", "192.0.2.1"};
 
       StringJoiner csvWhitelist = new StringJoiner(", ");
@@ -476,10 +509,12 @@ public class jros2SettingsTest
 
       // Define system properties
       System.setProperty(jros2SettingsProp.DOMAIN_ID_KEY, Integer.toString(domainId));
+      System.setProperty(jros2SettingsProp.INTRAPROCESS_DELIVERY_KEY, Boolean.toString(intraprocessDelivery));
       System.setProperty(jros2SettingsProp.INTERFACE_WHITELIST_KEY, csvWhitelist.toString());
 
       // Now it should have values
       assertTrue(systemPropertySettings.hasROSDomainId());
+      assertTrue(systemPropertySettings.hasIntraprocessDelivery());
       assertTrue(systemPropertySettings.hasInterfaceWhitelist());
 
       // The values should reflect the newly defined system properties
@@ -491,6 +526,7 @@ public class jros2SettingsTest
 
       // Change up the system properties
       int newDomainId = 219;
+      boolean newIntraprocessDelivery = false;
       String[] newInterfaceWhitelist = {"198.51.100.5"};
 
       StringJoiner newCSVWhitelist = new StringJoiner(", ");
@@ -499,10 +535,12 @@ public class jros2SettingsTest
 
       // Define system properties
       System.setProperty(jros2SettingsProp.DOMAIN_ID_KEY, Integer.toString(newDomainId));
+      System.setProperty(jros2SettingsProp.INTRAPROCESS_DELIVERY_KEY, Boolean.toString(newIntraprocessDelivery));
       System.setProperty(jros2SettingsProp.INTERFACE_WHITELIST_KEY, newCSVWhitelist.toString());
 
       // Should still have values
       assertTrue(systemPropertySettings.hasROSDomainId());
+      assertTrue(systemPropertySettings.hasIntraprocessDelivery());
       assertTrue(systemPropertySettings.hasInterfaceWhitelist());
 
       // Now the values should reflect the newly defined system properties


### PR DESCRIPTION
Added a configurable library setting:
- environment variable: `FASTDDS_INRAPROCESS_DELIVERY`
- system property: `fastdds.intraprocess.delivery`
- jros2.properties: `jros2.fastdds.intraprocess.delivery`

Setting to `true` sets intraprocess delivery to `FULL`

https://fast-dds.docs.eprosima.com/en/v3.2.2/fastdds/xml_configuration/library_settings.html#intra-process-delivery-xml-profile