### PR TITLE
Generator string fixes

### DIFF
--- a/buildSrc/src/main/resources/ROS2Message.st
+++ b/buildSrc/src/main/resources/ROS2Message.st
@@ -49,15 +49,15 @@ public class <context.name> implements ROS2Message\<<context.name>>
       <if(!field.constantValue)>
       <if(field.array)>
 <field.javaName> = new <field.javaType><if(field.fixedSize)>[<if(!field.defaultValueArray)><field.length><endif>]<if(field.defaultValueArray)> {<field.defaultValueArrayValues; wrap, anchor, separator=", ">\}<endif><else>(<if(field.upperBounded)><field.length><endif><if(field.objectSequence)><if(field.upperBounded)>, <endif><field.objectSequenceTypeClass><endif>)<endif>;
-      <if(field.fixedSize&&!field.builtinType)>
+      <if(field.fixedSize&&(!field.builtinType||field.builtinStringType))>
 // <field.name> is defined as a fixed-size array, so it is pre-allocated.
 for (int i = 0; i \< <field.javaName>.length; ++i)
 {
-   <field.javaName>[i] = new <field.javaType>();
+   <field.javaName>[i] = new <field.javaType>(<if(field.builtinStringType&&field.defaultValue)><field.defaultValue><endif><if(field.builtinStringType&&field.stringMaxLength)><field.stringLength><endif>);
 \}
       <endif>
       <elseif(!field.builtinType||field.builtinStringType)><! If not a builtin type excluding string, wstring !>
-<field.javaName> = new <field.javaType>(<if(field.builtinStringType&&field.defaultValue)><field.defaultValue><endif>);
+<field.javaName> = new <field.javaType>(<if(field.builtinStringType&&field.defaultValue)><field.defaultValue><endif><if(field.builtinStringType&&field.stringMaxLength)><field.stringLength><endif>);
       <elseif(field.builtinType&&!field.builtinStringType&&field.defaultValue)><! Handle default value assignments for builtin types other than string, wstring !>
 <field.javaName> = (<field.javaType>) <field.defaultValue>;
       <endif>

--- a/buildSrc/src/main/resources/ROS2Message.st
+++ b/buildSrc/src/main/resources/ROS2Message.st
@@ -48,7 +48,7 @@ public class <context.name> implements ROS2Message\<<context.name>>
       <context.fields:{ field |
       <if(!field.constantValue)>
       <if(field.array)>
-<field.javaName> = new <field.javaType><if(field.fixedSize)>[<if(!field.defaultValueArray)><field.length><endif>]<if(field.defaultValueArray)> {<field.defaultValueArrayValues; wrap, anchor, separator=", ">\}<endif><else>(<if(field.upperBounded)><field.length><endif><if(field.objectSequence)><if(field.upperBounded)>, <endif><field.objectSequenceTypeClass><endif>)<endif>;
+<field.javaName> = new <field.javaType><if(field.fixedSize)>[<if(!field.defaultValueArray)><field.length><endif>]<if(field.defaultValueArray)> {<field.defaultValueArrayValues; wrap, anchor, separator=", ">\}<endif><else>(<if(field.upperBounded)><field.length><if(field.builtinStringType&&field.stringMaxLength)>, <field.length>, <field.stringLength><endif><endif><if(field.objectSequence)><if(field.upperBounded)>, <endif><field.objectSequenceTypeClass><endif>)<endif>;
       <if(field.fixedSize&&(!field.builtinType||field.builtinStringType))>
 // <field.name> is defined as a fixed-size array, so it is pre-allocated.
 for (int i = 0; i \< <field.javaName>.length; ++i)

--- a/ros2_interfaces/jros2_example_interfaces/msg/TestMsg.msg
+++ b/ros2_interfaces/jros2_example_interfaces/msg/TestMsg.msg
@@ -28,4 +28,5 @@ string FOO="foo"
 string EXAMPLE='bar'
 
 string[3] three_strings
+string<=5[3] three_strings_each_max_length_of_five_chars
 sensor_msgs/Image[3] three_images

--- a/src/main/java-interfaces/jros2_example_interfaces/msg/dds/TestMsg.java
+++ b/src/main/java-interfaces/jros2_example_interfaces/msg/dds/TestMsg.java
@@ -99,7 +99,7 @@ public class TestMsg implements ROS2Message<TestMsg>
       up_to_ten_characters_string_ = new StringBuilder(10);
       up_to_five_unbounded_strings_ = new IDLStringSequence(5);
       unbounded_array_of_strings_up_to_ten_characters_each_ = new IDLStringSequence();
-      up_to_five_strings_up_to_ten_characters_each_ = new IDLStringSequence(5);
+      up_to_five_strings_up_to_ten_characters_each_ = new IDLStringSequence(5, 5, 10);
       x_ = (byte) 42;
       y_ = (short) -2000;
       full_name_ = new StringBuilder("John Doe");

--- a/src/main/java-interfaces/jros2_example_interfaces/msg/dds/TestMsg.java
+++ b/src/main/java-interfaces/jros2_example_interfaces/msg/dds/TestMsg.java
@@ -36,6 +36,7 @@ This file was generated from the following content:
    string EXAMPLE='bar'
 
    string[3] three_strings
+   string<=5[3] three_strings_each_max_length_of_five_chars
    sensor_msgs/Image[3] three_images
 ##################################################################################
 
@@ -81,6 +82,9 @@ public class TestMsg implements ROS2Message<TestMsg>
    public static final String FOO = "foo";
    public static final String EXAMPLE = "bar";
    private final StringBuilder[] three_strings_;
+   // Note: The length of each string in this sequence should not exceed 5 characters.
+   // This is not strictly enforced in Java / jros2.
+   private final StringBuilder[] three_strings_each_max_length_of_five_chars_;
    private final sensor_msgs.msg.dds.Image[] three_images_;
 
    public TestMsg()
@@ -92,7 +96,7 @@ public class TestMsg implements ROS2Message<TestMsg>
       five_integers_array_ = new int[5];
       up_to_five_integers_array_ = new IDLIntSequence(5);
       string_of_unbounded_size_ = new StringBuilder();
-      up_to_ten_characters_string_ = new StringBuilder();
+      up_to_ten_characters_string_ = new StringBuilder(10);
       up_to_five_unbounded_strings_ = new IDLStringSequence(5);
       unbounded_array_of_strings_up_to_ten_characters_each_ = new IDLStringSequence();
       up_to_five_strings_up_to_ten_characters_each_ = new IDLStringSequence(5);
@@ -102,6 +106,17 @@ public class TestMsg implements ROS2Message<TestMsg>
       samples_ = new IDLIntSequence();
       samples2_ = new int[] {-200, -100, 0, 100, 200};
       three_strings_ = new StringBuilder[3];
+      // three_strings is defined as a fixed-size array, so it is pre-allocated.
+      for (int i = 0; i < three_strings_.length; ++i)
+      {
+         three_strings_[i] = new StringBuilder();
+      }
+      three_strings_each_max_length_of_five_chars_ = new StringBuilder[3];
+      // three_strings_each_max_length_of_five_chars is defined as a fixed-size array, so it is pre-allocated.
+      for (int i = 0; i < three_strings_each_max_length_of_five_chars_.length; ++i)
+      {
+         three_strings_each_max_length_of_five_chars_[i] = new StringBuilder(5);
+      }
       three_images_ = new sensor_msgs.msg.dds.Image[3];
       // three_images is defined as a fixed-size array, so it is pre-allocated.
       for (int i = 0; i < three_images_.length; ++i)
@@ -134,6 +149,7 @@ public class TestMsg implements ROS2Message<TestMsg>
       currentAlignment += samples_.calculateSizeBytes(currentAlignment);
       currentAlignment += (5 * 4) + CDRBuffer.alignment(currentAlignment, (5 * 4)); // samples2_
       currentAlignment += (3 * 1) + CDRBuffer.alignment(currentAlignment, (3 * 1)); // three_strings_
+      currentAlignment += (3 * 1) + CDRBuffer.alignment(currentAlignment, (3 * 1)); // three_strings_each_max_length_of_five_chars_
       for (int i = 0; i < three_images_.length; ++i)
       {
          currentAlignment += three_images_[i].calculateSizeBytes(currentAlignment);
@@ -172,6 +188,10 @@ public class TestMsg implements ROS2Message<TestMsg>
       {
          buffer.writeString(three_strings_[i]);
       }
+      for (int i = 0; i < three_strings_each_max_length_of_five_chars_.length; ++i)
+      {
+         buffer.writeString(three_strings_each_max_length_of_five_chars_[i]);
+      }
       for (int i = 0; i < three_images_.length; ++i)
       {
          three_images_[i].serialize(buffer);
@@ -208,6 +228,10 @@ public class TestMsg implements ROS2Message<TestMsg>
       for (int i = 0; i < three_strings_.length; ++i)
       {
          buffer.readString(three_strings_[i]);
+      }
+      for (int i = 0; i < three_strings_each_max_length_of_five_chars_.length; ++i)
+      {
+         buffer.readString(three_strings_each_max_length_of_five_chars_[i]);
       }
       for (int i = 0; i < three_images_.length; ++i)
       {
@@ -249,6 +273,10 @@ public class TestMsg implements ROS2Message<TestMsg>
       for (int i = 0; i < three_strings_.length; ++i)
       {
          three_strings_[i] = from.three_strings_[i];
+      }
+      for (int i = 0; i < three_strings_each_max_length_of_five_chars_.length; ++i)
+      {
+         three_strings_each_max_length_of_five_chars_[i] = from.three_strings_each_max_length_of_five_chars_[i];
       }
       for (int i = 0; i < three_images_.length; ++i)
       {
@@ -360,6 +388,11 @@ public class TestMsg implements ROS2Message<TestMsg>
    public StringBuilder[] getThreeStrings()
    {
       return three_strings_;
+   }
+
+   public StringBuilder[] getThreeStringsEachMaxLengthOfFiveChars()
+   {
+      return three_strings_each_max_length_of_five_chars_;
    }
 
    public sensor_msgs.msg.dds.Image[] getThreeImages()

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -25,22 +25,23 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    protected StringBuilder[] elements;
    protected int position;
+   private final int defaultStringLength;
 
-   public IDLStringSequence(int capacity, int maxSize)
+   public IDLStringSequence(int capacity, int maxSize, int defaultStringLength)
    {
       super(capacity, maxSize);
-      position = 0;
+      this.defaultStringLength = defaultStringLength;
    }
 
    public IDLStringSequence(int maxSize)
    {
       super(maxSize);
-      position = 0;
+      defaultStringLength = -1;
    }
 
    public IDLStringSequence()
    {
-      position = 0;
+      defaultStringLength = -1;
    }
 
    @Override
@@ -91,7 +92,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    public StringBuilder add()
    {
-      return add(-1);
+      return add(defaultStringLength);
    }
 
    public StringBuilder add(int stringLength)

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLWStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLWStringSequence.java
@@ -19,21 +19,18 @@ import us.ihmc.fastddsjava.cdr.CDRBuffer;
 
 public class IDLWStringSequence extends IDLStringSequence
 {
-   public IDLWStringSequence(int capacity, int maxSize)
+   public IDLWStringSequence(int capacity, int maxSize, int defaultStringLength)
    {
-      super(capacity, maxSize);
-      position = 0;
+      super(capacity, maxSize, defaultStringLength);
    }
 
    public IDLWStringSequence(int maxSize)
    {
       super(maxSize);
-      position = 0;
    }
 
    public IDLWStringSequence()
    {
-      position = 0;
    }
 
    @Override

--- a/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
+++ b/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
@@ -522,7 +522,7 @@ public class IDLSequenceTest
       final int initialCapacity = 8;
       final int maxSize = -1;
 
-      IDLStringSequence sequence = new IDLStringSequence(initialCapacity, maxSize);
+      IDLStringSequence sequence = new IDLStringSequence(initialCapacity, maxSize, -1);
 
       // The sequence should have no elements
       assertEquals(0, sequence.elements());
@@ -604,9 +604,10 @@ public class IDLSequenceTest
    {
       final int initialCapacity = 8;
       final int maxSize = -1;
+      final int defaultStringLength = -1;
       final int codepointStart = 78419; // Starting at U+13253 (codepoint 78419)
 
-      IDLWStringSequence sequence = new IDLWStringSequence(initialCapacity, maxSize);
+      IDLWStringSequence sequence = new IDLWStringSequence(initialCapacity, maxSize, defaultStringLength);
 
       // The sequence should have no elements
       assertEquals(0, sequence.elements());


### PR DESCRIPTION
Fixes:
- Ensure StringBuilder gets instantiated with a capacity if the .msg specifies a fixed length string
- Ensure bounded string arrays get initialized with new StringBuilders (and instantiated with a capacity if set in .msg)