### PR TITLE
Subscriptions without callbacks

### DIFF
--- a/src/main/java/us/ihmc/jros2/ROS2Node.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Node.java
@@ -427,11 +427,30 @@ public class ROS2Node implements Closeable
       return createSubscription(topic, callback, ROS2QoSProfile.DEFAULT);
    }
 
+   /**
+    * Create a subscription without any callback for when new data is received. At any time, you can use {@link ROS2Subscription#getReader()} to access
+    * received messages. Use this in conjunction with {@link ROS2Subscription#hasHadData()} and {@link ROS2Subscription#hasNewData()} to strategically control
+    * when you use the subscription reader.
+    *
+    * @param topic      the ROS 2 topic, (see {@link ROS2Topic} for how to use.
+    * @param qosProfile specify what quality-of-service settings you want for this subscription. Note: subscription and publisher QoS must match if you want
+    *                   them to communicate.
+    * @return the subscription instance, you do not have to store this as a field or manage it in any way if you don't need to.
+    */
    public <T extends ROS2Message<T>> ROS2Subscription<T> createSubscription(ROS2Topic<T> topic, ROS2QoSProfile qosProfile)
    {
       return createSubscription(topic, null, qosProfile);
    }
 
+   /**
+    * Create a subscription without any callback for when new data is received. At any time, you can use {@link ROS2Subscription#getReader()} to access
+    * received messages. Use this in conjunction with {@link ROS2Subscription#hasHadData()} and {@link ROS2Subscription#hasNewData()} to strategically control
+    * when you use the subscription reader.
+    * This method will create a subscription using the default quality-of-service settings. See {@link ROS2QoSProfile#DEFAULT}.
+    *
+    * @param topic the ROS 2 topic, (see {@link ROS2Topic} for how to use.
+    * @return the subscription instance, you do not have to store this as a field or manage it in any way if you don't need to.
+    */
    public <T extends ROS2Message<T>> ROS2Subscription<T> createSubscription(ROS2Topic<T> topic)
    {
       return createSubscription(topic, null, ROS2QoSProfile.DEFAULT);

--- a/src/main/java/us/ihmc/jros2/ROS2Node.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Node.java
@@ -427,6 +427,16 @@ public class ROS2Node implements Closeable
       return createSubscription(topic, callback, ROS2QoSProfile.DEFAULT);
    }
 
+   public <T extends ROS2Message<T>> ROS2Subscription<T> createSubscription(ROS2Topic<T> topic, ROS2QoSProfile qosProfile)
+   {
+      return createSubscription(topic, null, qosProfile);
+   }
+
+   public <T extends ROS2Message<T>> ROS2Subscription<T> createSubscription(ROS2Topic<T> topic)
+   {
+      return createSubscription(topic, null, ROS2QoSProfile.DEFAULT);
+   }
+
    /**
     * Create a subscription using a {@link ROS2SubscriptionCallbackSampler}.
     * In the callback, you are given a sample of {@param T} message type.

--- a/src/main/java/us/ihmc/jros2/ROS2Subscription.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Subscription.java
@@ -266,6 +266,7 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
 
    /**
     * If this subscription has received data at least one time.
+    *
     * @return true if received data at least once, false if never received data
     */
    public boolean hasHadData()
@@ -275,6 +276,7 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
 
    /**
     * If this subscription has received data that has not been read by the subscription reader,
+    *
     * @return true if there exists unread data, false if not
     */
    public boolean hasNewData()

--- a/src/main/java/us/ihmc/jros2/ROS2Subscription.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Subscription.java
@@ -62,8 +62,8 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
    /*
     * Read buffer and readers
     */
-   private final CDRBuffer readBuffer;
-   private final ROS2SubscriptionCallback<T> callback;
+   protected final CDRBuffer readBuffer;
+   private final ROS2SubscriptionCallback<T> callback; // The callback may be null
    private final ROS2SubscriptionReader<T> subscriptionReader;
 
    /*
@@ -79,12 +79,18 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
    private final int statisticsCalculatorCount;
    private long lastReceiveTime;
 
+   /*
+    * Flags relating to received data from the native callback
+    */
+   protected boolean flagHadData;
+   protected boolean flagNewData;
+
    /**
     * Use {@link ROS2Node#createSubscription(ROS2Topic, ROS2SubscriptionCallback, ROS2QoSProfile)}
     */
    protected ROS2Subscription(Pointer fastddsParticipant,
                               String subscriberProfileName,
-                              ROS2SubscriptionCallback<T> callback,
+                              ROS2SubscriptionCallback<T> callback /* Can be null */,
                               ROS2Topic<T> topic,
                               TopicData topicData)
    {
@@ -97,7 +103,7 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
 
       readBuffer = new CDRBuffer();
       sampleInfo = new SampleInfo();
-      subscriptionReader = new ROS2SubscriptionReader<>(readBuffer, topic);
+      subscriptionReader = new ROS2SubscriptionReader<>(this);
 
       statisticsCalculatorCount = MessageMetadataType.values.length;
       statisticsCalculators = new StatisticsCalculator[statisticsCalculatorCount];
@@ -135,11 +141,6 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
       fastddsjava_datareader_set_listener(fastddsDataReader, listener);
    }
 
-   public int getUnreadCount()
-   {
-      return fastddsjava_datareader_get_unread_count(fastddsDataReader);
-   }
-
    private static final int OK = RETCODE_OK();
 
    private void onDataCallback()
@@ -147,20 +148,29 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
       closeLock.readLock().lock();
       try
       {
-         if (callback != null && !closed)
+         if (!closed)
          {
             while (OK == fastddsjava_datareader_take_next_sample(fastddsDataReader, topicDataWrapper, sampleInfo))
             {
                long receptionTime = System.currentTimeMillis();
                int payloadSizeBytes = (int) topicDataWrapper.data_vector().size();
 
-               readBuffer.ensureRemainingCapacity(payloadSizeBytes);
-               // Rewind buffer to ensure we're starting at position = 0
-               readBuffer.rewind();
+               synchronized (readBuffer)
+               {
+                  readBuffer.ensureRemainingCapacity(payloadSizeBytes);
+                  // Rewind buffer to ensure we're starting at position = 0
+                  readBuffer.rewind();
 
-               topicDataWrapper.data_ptr().get(readBuffer.getBufferUnsafe().array(), 0, payloadSizeBytes);
+                  topicDataWrapper.data_ptr().get(readBuffer.getBufferUnsafe().array(), 0, payloadSizeBytes);
 
-               callback.onMessage(subscriptionReader);
+                  flagHadData = true;
+                  flagNewData = true;
+               }
+
+               if (callback != null)
+               {
+                  callback.onMessage(subscriptionReader);
+               }
 
                long timestampMillis = subscriptionReader.getLastMessageTimestamp();
                recordStatistics(payloadSizeBytes, timestampMillis, receptionTime);
@@ -242,9 +252,45 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
       statisticsCalculators[messageMetadataType.ordinal()].read(statisticToPack);
    }
 
+   /**
+    * If this subscription has been closed. A closed subscription will not receive any new data from publishers. Once closed, a subscription cannot be reused.
+    * Subscriptions are closed automatically when the parent {@link ROS2Node} is destroyed. To manually close this subscription, use
+    * {@link ROS2Node#destroySubscription(ROS2Subscription)}.
+    *
+    * @return true if closed, false if not closed
+    */
    public boolean isClosed()
    {
       return closed;
+   }
+
+   /**
+    * If this subscription has received data at least one time.
+    * @return true if received data at least once, false if never received data
+    */
+   public boolean hasHadData()
+   {
+      return flagHadData;
+   }
+
+   /**
+    * If this subscription has received data that has not been read by the subscription reader,
+    * @return true if there exists unread data, false if not
+    */
+   public boolean hasNewData()
+   {
+      return flagNewData;
+   }
+
+   /**
+    * Get the reader responsible for packing the CDR read buffer into {@link ROS2Message} type classes.
+    * Allows you to read messages received by this subscription.
+    *
+    * @return the subscription reader
+    */
+   public ROS2SubscriptionReader<T> getReader()
+   {
+      return subscriptionReader;
    }
 
    /**

--- a/src/main/java/us/ihmc/jros2/ROS2Subscription.java
+++ b/src/main/java/us/ihmc/jros2/ROS2Subscription.java
@@ -275,7 +275,7 @@ public class ROS2Subscription<T extends ROS2Message<T>> implements MessageStatis
    }
 
    /**
-    * If this subscription has received data that has not been read by the subscription reader,
+    * If this subscription has received data that has not been read by the subscription reader.
     *
     * @return true if there exists unread data, false if not
     */

--- a/src/main/java/us/ihmc/jros2/ROS2SubscriptionReader.java
+++ b/src/main/java/us/ihmc/jros2/ROS2SubscriptionReader.java
@@ -33,11 +33,12 @@ public class ROS2SubscriptionReader<T extends ROS2Message<T>>
       jros2.load();
    }
 
-   private final CDRBuffer readBuffer;
-   private final ROS2Topic<T> topic;
+   private final ROS2Subscription<T> parent;
 
+   /*
+    * Statistics
+    */
    private long lastMessageTimestamp;
-
    /**
     * A method reference to the getter for the first {@link Header} field within the ROS2Message topic type.
     * Used for statistics.
@@ -47,25 +48,58 @@ public class ROS2SubscriptionReader<T extends ROS2Message<T>>
    /**
     * Use {@link ROS2Node#createSubscription(ROS2Topic, ROS2SubscriptionCallback, ROS2QoSProfile)}
     */
-   protected ROS2SubscriptionReader(CDRBuffer readBuffer, ROS2Topic<T> topic)
+   protected ROS2SubscriptionReader(ROS2Subscription<T> parent)
    {
-      this.readBuffer = readBuffer;
-      this.topic = topic;
+      this.parent = parent;
 
       lastMessageTimestamp = Long.MIN_VALUE;
-      getHeaderMethod = ROS2Message.getHeaderMethod(topic.getType());
+      getHeaderMethod = ROS2Message.getHeaderMethod(parent.getTopicType());
    }
 
    /**
-    * Read from the {@link CDRBuffer} into data (does not allocate any heap memory).
+    * Reads data from the {@link CDRBuffer} into the given message instance without allocating heap memory.
     *
-    * @param data The message to pack
+    * @param data   the message object to populate with deserialized data
+    * @param reread if true, allows re-reading the last message even if no new data has been received;
+    *               if false, returns immediately when data has already been read
+    * @return true if data was read into {@param data}; false otherwise
     */
-   public void read(T data)
+   public boolean read(T data, boolean reread)
    {
-      readBuffer.readPayloadHeader();
+      synchronized (parent.readBuffer)
+      {
+         /*
+          * If there was no data ever received by the native callback, don't bother reading from the buffer because there
+          * will be nothing in it.
+          */
+         if (!parent.flagHadData)
+         {
+            return false;
+         }
 
-      data.deserialize(readBuffer);
+         /*
+          * If the buffer has already been read from. The buffer only stores 1 message at a time.
+          */
+         boolean alreadyRead = parent.readBuffer.getBufferUnsafe().position() > 0;
+
+         if (alreadyRead)
+         {
+            if (reread)
+            {
+               parent.readBuffer.rewind();
+            }
+            else
+            {
+               return false;
+            }
+         }
+
+         parent.readBuffer.readPayloadHeader();
+
+         data.deserialize(parent.readBuffer);
+
+         parent.flagNewData = false;
+      }
 
       /*
        * Generate age statistics for messages which have a Header field (https://github.com/ros2/common_interfaces/blob/humble/std_msgs/msg/Header.msg)
@@ -86,21 +120,53 @@ public class ROS2SubscriptionReader<T extends ROS2Message<T>>
             getHeaderMethod = null;
          }
       }
+
+      return true;
    }
 
    /**
-    * Read from the {@link CDRBuffer} and return a new message (allocates a new instance of the message type).
+    * Reads data from the {@link CDRBuffer} into the given message instance without allocating heap memory.
+    * If the buffer has already been read from, it will reset the buffer's position and reread the same message.
+    *
+    * @param data the message object to populate with deserialized data
+    * @return true if data was read into {@param data}; false otherwise
     */
-   public T read()
+   public boolean read(T data)
    {
-      T data = ROS2Message.createInstance(topic.getType());
+      return read(data, true);
+   }
+
+   /**
+    * Reads data from the {@link CDRBuffer} into a newly created instance of the message type.
+    *
+    * @param reread if true, allows re-reading the last message even if no new data has been received;
+    *               if false, returns immediately when data has already been read
+    * @return the instance of the message, null if the reader was unable to read any data from the buffer
+    */
+   public T read(boolean reread)
+   {
+      T data = ROS2Message.createInstance(parent.getTopicType());
 
       if (data != null)
       {
-         read(data);
+         if (!read(data, reread))
+         {
+            data = null;
+         }
       }
 
       return data;
+   }
+
+   /**
+    * Reads data from the {@link CDRBuffer} into a newly created instance of the message type.
+    * If the buffer has already been read from, it will reset the buffer's position and reread the same message.
+    *
+    * @return the instance of the message, null if the reader was unable to read any data from the buffer
+    */
+   public T read()
+   {
+      return read(true);
    }
 
    long getLastMessageTimestamp()

--- a/src/test/java/us/ihmc/jros2/ROS2PublishSubscribeTest.java
+++ b/src/test/java/us/ihmc/jros2/ROS2PublishSubscribeTest.java
@@ -16,6 +16,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
@@ -264,8 +265,141 @@ public class ROS2PublishSubscribeTest
    @Test
    @EnabledOnOs(OS.LINUX)
    @Timeout(30)
-   // Subscription sampler
+   // Callback-less subscription
    public void testROS2Subscription3() throws InterruptedException, IOException
+   {
+      final String data = "This is a test. This is only a test.";
+      final String topicName = "/ihmc/test_string";
+
+      // Create the ROS 2 node, topic, and subscription
+      ROS2Node ros2Node = new ROS2Node("test_node");
+      ROS2Topic<std_msgs.msg.dds.String> topic = new ROS2Topic<>(topicName, std_msgs.msg.dds.String.class);
+
+      ROS2Subscription<std_msgs.msg.dds.String> subscription = ros2Node.createSubscription(topic);
+
+      // Launch a ROS 2 process to publish a String message
+      Process process = ROS2TestTools.launchROS2PublishProcess(ros2Node.getDomainId(),
+                                                               "--once",
+                                                               topicName,
+                                                               "std_msgs/msg/String",
+                                                               "{data: " + data + "}",
+                                                               Redirect.INHERIT,
+                                                               Redirect.INHERIT);
+
+      while (!subscription.hasNewData())
+      {
+         LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(50));
+      }
+
+      std_msgs.msg.dds.String msg = subscription.getReader().read();
+
+      // Assert the received value is correct
+      assertEquals(data, msg.getData().toString());
+
+      // Ensure the ROS 2 publish process ends
+      process.waitFor();
+
+      ros2Node.close();
+   }
+
+   @Test
+   @EnabledOnOs(OS.LINUX)
+   @Timeout(30)
+   // Standard subscription with a couple threads that access the subscription's reader directly repeatedly
+   public void testROS2Subscription4() throws InterruptedException, IOException
+   {
+      final String data = "This is a test. This is only a test.";
+      final String topicName = "/ihmc/test_string";
+
+      // Create the ROS 2 node, topic, and subscription
+      ROS2Node ros2Node = new ROS2Node("test_node");
+      ROS2Topic<std_msgs.msg.dds.String> topic = new ROS2Topic<>(topicName, std_msgs.msg.dds.String.class);
+
+      // This subscription is allocation-free, so we allocate the message object once and reuse it for each subscription callback
+      std_msgs.msg.dds.String msg = new std_msgs.msg.dds.String();
+      std_msgs.msg.dds.String msgThread1 = new std_msgs.msg.dds.String();
+      std_msgs.msg.dds.String msgThread2 = new std_msgs.msg.dds.String();
+      final Object sync = new Object();
+      ROS2Subscription<std_msgs.msg.dds.String> subscription = ros2Node.createSubscription(topic, reader ->
+      {
+         reader.read(msg);
+
+         synchronized (sync)
+         {
+            sync.notify();
+         }
+      }, ROS2QoSProfile.DEFAULT);
+
+      Thread thread1 = new Thread(() ->
+      {
+         // Random read in another thread in a loop
+         while (!subscription.hasHadData())
+         {
+            // Try to read even though the subscription hasn't had any data yet
+            if (subscription.getReader().read() != null)
+            {
+               throw new RuntimeException("Unexpected read state");
+            }
+
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+         }
+
+         subscription.getReader().read(msgThread1);
+      }, "ExtraReadThread1");
+      thread1.start();
+      Thread thread2 = new Thread(() ->
+      {
+         // Random read in another thread in a loop
+         while (!subscription.hasHadData())
+         {
+            // Try to read even though the subscription hasn't had any data yet
+            if (subscription.getReader().read() != null)
+            {
+               throw new RuntimeException("Unexpected read state");
+            }
+
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+         }
+         subscription.getReader().read(msgThread2);
+      }, "ExtraReadThread2");
+      thread2.start();
+
+      // Launch a ROS 2 process to publish a String message
+      Process process = ROS2TestTools.launchROS2PublishProcess(ros2Node.getDomainId(),
+                                                               "--once",
+                                                               topicName,
+                                                               "std_msgs/msg/String",
+                                                               "{data: " + data + "}",
+                                                               Redirect.INHERIT,
+                                                               Redirect.INHERIT);
+      // Wait for subscription to receive the String message
+      synchronized (sync)
+      {
+         if (msg.getData().isEmpty())
+         {
+            sync.wait();
+         }
+      }
+
+      thread1.join();
+      thread2.join();
+
+      // Assert the received value is correct from the callback and the 2 threads
+      assertEquals(data, msg.getData().toString());
+      assertEquals(data, msgThread1.getData().toString());
+      assertEquals(data, msgThread2.getData().toString());
+
+      // Ensure the ROS 2 publish process ends
+      process.waitFor();
+
+      ros2Node.close();
+   }
+
+   @Test
+   @EnabledOnOs(OS.LINUX)
+   @Timeout(30)
+   // Subscription sampler
+   public void testROS2Subscription5() throws InterruptedException, IOException
    {
       final String data = "This is a test. This is only a test.";
       final String topicName = "/ihmc/test_string";


### PR DESCRIPTION
How to use:

Instead of a callback giving you access to the subscription's reader, you can now use ROS2Subscription#getReader()

```
ROS2Node node = new ROS2Node("test_node");
ROS2Topic<Int32> topic = new ROS2Topic("/test_topic", Int32.class);

ROS2Subscription<Int32> subscription = node.createSubscription(topic);

while (true) 
{
  // In normal circumstances, you probably don't need to use this method. It's just there in case (and is used internally).
  if (!subscription.hasHadData())
  {
    System.out.println("The subscription has not received any data yet.");
  }

  if (subscription.hasNewData())
  {
    Int32 msg1 = subscription.getReader().read();
    // At this point, subscription.hasNewData() will be false

    Int32 msg2 = subscription.getReader().read();
    // msg1 will equal msg2; the default read() with no args will "reread" from the same buffer if there has been no new message

    Int32 msg3 = subscription.getReader().read(false);
    // msg3 will be null, when passing false to read(), it will not reread an already read message from the buffer

    Int32 msg4 = new Int32();
    if (subscription.getReader().read(msg4))
    {
      // This will return true if successfully read a message, in this case it will be true because it "reread" from the same buffer
    }

    Int32 msg5 = new Int32();
    if (subscription.getReader().read(msg5, false))
    {
      // This will return false because the "reread" param has been set to false. It will not "reread" from the same buffer
    }  
  }
}

```
