### PR TITLE
Cleanup of IDLSequence classes

### DIFF
--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -77,7 +77,7 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
     *
     * @return the buffer of boolean values (as bytes), may be null
     */
-   public ByteBuffer getBufferUnsafe()
+   public ByteBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -94,13 +94,20 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
       return buffer.get(index) == 1;
    }
 
+   /**
+    * Get the backing heap {@link ByteBuffer} holding all boolean values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of boolean values, may be null
+    */
    public ByteBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -16,99 +16,89 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.ByteBuffer;
 
 public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
 {
-   private ByteBuffer buffer;
+   private static final BooleanBufferWrapper EMPTY_BUFFER = new BooleanBufferWrapper(0);
 
-   public IDLBoolSequence(int capacity, int maxSize)
+   private BooleanBufferWrapper buffer;
+
+   public IDLBoolSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLBoolSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLBoolSequence()
+   public IDLBoolSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
+      buffer = EMPTY_BUFFER;
+
+      ensureMinCapacity(capacity);
+   }
+
+   /**
+    * Get the backing heap {@link BooleanBufferWrapper} holding all boolean values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of boolean values
+    */
+   public BooleanBufferWrapper getBuffer()
+   {
+      return buffer;
    }
 
    @Override
    public int elements()
    {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
       return buffer.position();
    }
 
    @Override
    public int capacity()
    {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
       return buffer.capacity();
    }
 
    @Override
    public void clear()
    {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      buffer.clear();
    }
 
    /**
-    * Get the backing heap {@link ByteBuffer} holding all boolean values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
-    *
-    * @return the buffer of boolean values (as bytes), may be null
+    * {@inheritDoc}
     */
-   public ByteBuffer getBuffer()
-   {
-      return buffer;
-   }
-
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public boolean ensureMinCapacity(int desiredCapacity)
    {
-      if (capacity() < desiredCapacity)
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         ByteBuffer newBuffer = ByteBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            BooleanBufferWrapper newBuffer = new BooleanBufferWrapper(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,17 +110,13 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
-      buffer.put(cdrBuffer.readByte());
+      buffer.put(cdrBuffer.readByte() == 1);
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
-      cdrBuffer.writeByte(buffer.get(i));
+      cdrBuffer.writeByte((byte) (buffer.get(i) ? 1 : 0));
    }
 
    @Override
@@ -143,5 +129,77 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
 
       buffer.put(0, other.buffer, 0, othersElements);
       buffer.position(othersElements);
+   }
+
+   public static class BooleanBufferWrapper
+   {
+      private final ByteBuffer byteBuffer;
+      private final int capacity;
+
+      public BooleanBufferWrapper(int capacity)
+      {
+         this.capacity = capacity;
+         this.byteBuffer = ByteBuffer.allocate(capacity);
+      }
+
+      public ByteBuffer getByteBuffer()
+      {
+         return byteBuffer;
+      }
+
+      public void put(int index, boolean value)
+      {
+         byteBuffer.put(index, (byte) (value ? 1 : 0));
+      }
+
+      public boolean get(int index)
+      {
+         return byteBuffer.get(index) != 0;
+      }
+
+      public void put(boolean value)
+      {
+         byteBuffer.put((byte) (value ? 1 : 0));
+      }
+
+      public boolean get()
+      {
+         return byteBuffer.get() != 0;
+      }
+
+      public BooleanBufferWrapper put(int dstIndex, BooleanBufferWrapper src, int srcIndex, int length)
+      {
+         for (int i = 0; i < length; i++)
+         {
+            byteBuffer.put(dstIndex + i, src.byteBuffer.get(srcIndex + i));
+         }
+         return this;
+      }
+
+      public int capacity()
+      {
+         return capacity;
+      }
+
+      public int position()
+      {
+         return byteBuffer.position();
+      }
+
+      public BooleanBufferWrapper position(int newPosition)
+      {
+         byteBuffer.position(newPosition);
+         return this;
+      }
+
+      public BooleanBufferWrapper clear()
+      {
+         byteBuffer.clear();
+         for (int i = 0; i < capacity; i++)
+         {
+            byteBuffer.put(i, (byte) 0);
+         }
+         return this;
+      }
    }
 }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -195,10 +195,6 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
       public BooleanBufferWrapper clear()
       {
          byteBuffer.clear();
-         for (int i = 0; i < capacity; i++)
-         {
-            byteBuffer.put(i, (byte) 0);
-         }
          return this;
       }
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -57,7 +57,7 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLBoolSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.ByteBuffer;
 
@@ -30,7 +31,7 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
 
    public IDLBoolSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLBoolSequence()
@@ -69,37 +70,12 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
       }
    }
 
-   public void add(boolean element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put((byte) (element ? 1 : 0));
-   }
-
-   public boolean get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index) == 1;
-   }
-
    /**
     * Get the backing heap {@link ByteBuffer} holding all boolean values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
     * of the correct capacity first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of boolean values, may be null
+    * @return the buffer of boolean values (as bytes), may be null
     */
    public ByteBuffer getBufferUnsafe()
    {
@@ -111,13 +87,24 @@ public class IDLBoolSequence extends IDLSequence<IDLBoolSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          ByteBuffer newBuffer = ByteBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.ByteBuffer;
 
@@ -30,7 +31,7 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
 
    public IDLByteSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLByteSequence()
@@ -69,31 +70,6 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
       }
    }
 
-   public void add(byte element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public byte get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link ByteBuffer} holding all byte values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          ByteBuffer newBuffer = ByteBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
@@ -77,7 +77,7 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
     *
     * @return the buffer of byte values, may be null
     */
-   public ByteBuffer getBufferUnsafe()
+   public ByteBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
@@ -22,52 +22,45 @@ import java.nio.ByteBuffer;
 
 public class IDLByteSequence extends IDLSequence<IDLByteSequence>
 {
+   private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+
    private ByteBuffer buffer;
 
-   public IDLByteSequence(int capacity, int maxSize)
+   public IDLByteSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLByteSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLByteSequence()
+   public IDLByteSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
+      buffer = EMPTY_BUFFER;
+
+      ensureMinCapacity(capacity);
    }
 
    @Override
    public int elements()
    {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
       return buffer.position();
    }
 
    @Override
    public int capacity()
    {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
       return buffer.capacity();
    }
 
    @Override
    public void clear()
    {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      buffer.clear();
    }
 
    /**
@@ -82,33 +75,31 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
       return buffer;
    }
 
+   /**
+    * {@inheritDoc}
+    */
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public boolean ensureMinCapacity(int desiredCapacity)
    {
-      if (capacity() < desiredCapacity)
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         ByteBuffer newBuffer = ByteBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            ByteBuffer newBuffer = ByteBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
@@ -94,13 +94,20 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link ByteBuffer} holding all byte values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of byte values, may be null
+    */
    public ByteBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLByteSequence.java
@@ -16,7 +16,6 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.ByteBuffer;
 
@@ -46,7 +45,7 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -129,7 +128,7 @@ public class IDLByteSequence extends IDLSequence<IDLByteSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.CharBuffer;
 
 public class IDLCharSequence extends IDLSequence<IDLCharSequence>
 {
+   private static final CharBuffer EMPTY_BUFFER = CharBuffer.allocate(0);
+
    private CharBuffer buffer;
 
-   public IDLCharSequence(int capacity, int maxSize)
+   public IDLCharSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLCharSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLCharSequence()
+   public IDLCharSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link CharBuffer} holding all char values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct
+    * capacity first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of char values, may be null
+    * @return the buffer of char values
     */
    public CharBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         CharBuffer newBuffer = CharBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            CharBuffer newBuffer = CharBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readChar());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeChar(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.CharBuffer;
 
@@ -30,7 +31,7 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
 
    public IDLCharSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLCharSequence()
@@ -69,31 +70,6 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
       }
    }
 
-   public void add(char element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public char get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link CharBuffer} holding all char values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          CharBuffer newBuffer = CharBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
@@ -94,13 +94,20 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link CharBuffer} holding all char values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of char values, may be null
+    */
    public CharBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
@@ -57,7 +57,7 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLCharSequence.java
@@ -77,7 +77,7 @@ public class IDLCharSequence extends IDLSequence<IDLCharSequence>
     *
     * @return the buffer of char values, may be null
     */
-   public CharBuffer getBufferUnsafe()
+   public CharBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
@@ -77,7 +77,7 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
     *
     * @return the buffer of double values, may be null
     */
-   public DoubleBuffer getBufferUnsafe()
+   public DoubleBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
@@ -94,13 +94,20 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link DoubleBuffer} holding all double values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of double values, may be null
+    */
    public DoubleBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
@@ -57,7 +57,7 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.DoubleBuffer;
 
 public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
 {
+   private static final DoubleBuffer EMPTY_BUFFER = DoubleBuffer.allocate(0);
+
    private DoubleBuffer buffer;
 
-   public IDLDoubleSequence(int capacity, int maxSize)
+   public IDLDoubleSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLDoubleSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLDoubleSequence()
+   public IDLDoubleSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link DoubleBuffer} holding all double values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of double values, may be null
+    * @return the buffer of double values
     */
    public DoubleBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         DoubleBuffer newBuffer = DoubleBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            DoubleBuffer newBuffer = DoubleBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readDouble());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeDouble(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLDoubleSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.DoubleBuffer;
 
@@ -30,7 +31,7 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
 
    public IDLDoubleSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLDoubleSequence()
@@ -69,31 +70,6 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
       }
    }
 
-   public void add(double element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public double get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link DoubleBuffer} holding all double values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLDoubleSequence extends IDLSequence<IDLDoubleSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          DoubleBuffer newBuffer = DoubleBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.FloatBuffer;
 
@@ -30,7 +31,7 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
 
    public IDLFloatSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLFloatSequence()
@@ -69,31 +70,6 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
       }
    }
 
-   public void add(float element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public float get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link FloatBuffer} holding all float values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          FloatBuffer newBuffer = FloatBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
@@ -77,7 +77,7 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
     *
     * @return the buffer of float values, may be null
     */
-   public FloatBuffer getBufferUnsafe()
+   public FloatBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
@@ -57,7 +57,7 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
@@ -94,13 +94,20 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link FloatBuffer} holding all float values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of float values, may be null
+    */
    public FloatBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLFloatSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.FloatBuffer;
 
 public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
 {
+   private static final FloatBuffer EMPTY_BUFFER = FloatBuffer.allocate(0);
+
    private FloatBuffer buffer;
 
-   public IDLFloatSequence(int capacity, int maxSize)
+   public IDLFloatSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLFloatSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLFloatSequence()
+   public IDLFloatSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link FloatBuffer} holding all float values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of float values, may be null
+    * @return the buffer of float values
     */
    public FloatBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         FloatBuffer newBuffer = FloatBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            FloatBuffer newBuffer = FloatBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLFloatSequence extends IDLSequence<IDLFloatSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readFloat());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeFloat(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
@@ -77,7 +77,7 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
     *
     * @return the buffer of int values, may be null
     */
-   public IntBuffer getBufferUnsafe()
+   public IntBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
@@ -94,13 +94,20 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link IntBuffer} holding all int values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of int values, may be null
+    */
    public IntBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.IntBuffer;
 
@@ -30,7 +31,7 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
 
    public IDLIntSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLIntSequence()
@@ -69,31 +70,6 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
       }
    }
 
-   public void add(int element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public int get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link IntBuffer} holding all int values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          IntBuffer newBuffer = IntBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
@@ -57,7 +57,7 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLIntSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.IntBuffer;
 
 public class IDLIntSequence extends IDLSequence<IDLIntSequence>
 {
+   private static final IntBuffer EMPTY_BUFFER = IntBuffer.allocate(0);
+
    private IntBuffer buffer;
 
-   public IDLIntSequence(int capacity, int maxSize)
+   public IDLIntSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLIntSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLIntSequence()
+   public IDLIntSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link IntBuffer} holding all int values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of int values, may be null
+    * @return the buffer of int values
     */
    public IntBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         IntBuffer newBuffer = IntBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            IntBuffer newBuffer = IntBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLIntSequence extends IDLSequence<IDLIntSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readInt());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeInt(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.LongBuffer;
 
@@ -30,7 +31,7 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
 
    public IDLLongSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLLongSequence()
@@ -69,31 +70,6 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
       }
    }
 
-   public void add(long element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public long get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link LongBuffer} holding all long values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          LongBuffer newBuffer = LongBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
@@ -57,7 +57,7 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
@@ -94,13 +94,20 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link LongBuffer} holding all long values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of long values, may be null
+    */
    public LongBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.LongBuffer;
 
 public class IDLLongSequence extends IDLSequence<IDLLongSequence>
 {
+   private static final LongBuffer EMPTY_BUFFER = LongBuffer.allocate(0);
+
    private LongBuffer buffer;
 
-   public IDLLongSequence(int capacity, int maxSize)
+   public IDLLongSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLLongSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLLongSequence()
+   public IDLLongSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link LongBuffer} holding all long values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of long values, may be null
+    * @return the buffer of long values
     */
    public LongBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         LongBuffer newBuffer = LongBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            LongBuffer newBuffer = LongBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readLong());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeLong(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLLongSequence.java
@@ -77,7 +77,7 @@ public class IDLLongSequence extends IDLSequence<IDLLongSequence>
     *
     * @return the buffer of long values, may be null
     */
-   public LongBuffer getBufferUnsafe()
+   public LongBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
@@ -134,7 +134,7 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
 
    @Override
    @SuppressWarnings("unchecked")
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (elements == null)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
@@ -22,30 +22,41 @@ import us.ihmc.log.LogTools;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
+@SuppressWarnings("unchecked")
 public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<IDLObjectSequence<T>>
 {
-   private final Class<T> clazz;
+   private static final CDRSerializable[] EMPTY_ARRAY = new CDRSerializable[0];
 
+   private final Class<T> clazz;
    private T[] elements;
    private int position;
 
    public IDLObjectSequence(int capacity, int maxSize, Class<T> clazz)
    {
       super(capacity, maxSize);
+
       this.clazz = clazz;
+      elements = (T[]) EMPTY_ARRAY;
       position = 0;
+
+      ensureMinCapacity(capacity);
    }
 
    public IDLObjectSequence(int capacity, Class<T> clazz)
    {
       super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+
       this.clazz = clazz;
+      elements = (T[]) EMPTY_ARRAY;
       position = 0;
+
+      ensureMinCapacity(capacity);
    }
 
    public IDLObjectSequence(Class<T> clazz)
    {
       this.clazz = clazz;
+      elements = (T[]) EMPTY_ARRAY;
       position = 0;
    }
 
@@ -72,11 +83,6 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    @Override
    public int capacity()
    {
-      if (elements == null)
-      {
-         return 0;
-      }
-
       return elements.length;
    }
 
@@ -117,49 +123,38 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
       return elements[index];
    }
 
-   public T[] getArrayUnsafe()
-   {
-      return elements;
-   }
-
+   /**
+    * {@inheritDoc}
+    */
    @Override
-   @SuppressWarnings("unchecked")
-   public void ensureMinCapacity(int desiredCapacity)
+   public boolean ensureMinCapacity(int desiredCapacity)
    {
-      if (capacity() < desiredCapacity)
+      if (elements.length < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-         }
-
-         if (elements == null)
-         {
-            elements = (T[]) new CDRSerializable[desiredCapacity];
+            return false;
          }
          else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * 2), getMaxSize());
             elements = Arrays.copyOf(elements, desiredCapacity);
          }
       }
+
+      return true;
    }
 
    @Override
    public int elementSizeBytes(int currentAlignment, int i)
    {
-      assert elements != null;
-      assert i < elements();
-
       return elements[i].calculateSizeBytes(currentAlignment);
    }
 
    @Override
    public void readElement(CDRBuffer buffer)
    {
-      assert elements != null;
-      assert position < elements.length;
-
       if (elements[position] == null)
       {
          elements[position] = newInstance();
@@ -173,9 +168,6 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    @Override
    public void writeElement(int i, CDRBuffer buffer)
    {
-      assert elements != null;
-      assert i < elements();
-
       if (elements[i] == null)
       {
          elements[i] = newInstance();
@@ -187,9 +179,6 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    @Override
    public void set(IDLObjectSequence<T> other)
    {
-      assert clazz == other.clazz;
-      assert other.elements != null;
-
       clear();
 
       int othersElements = other.elements();

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
@@ -17,6 +17,7 @@ package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
 import us.ihmc.fastddsjava.cdr.CDRSerializable;
+import us.ihmc.log.LogTools;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -37,7 +38,7 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
 
    public IDLObjectSequence(int capacity, Class<T> clazz)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
       this.clazz = clazz;
       position = 0;
    }
@@ -56,8 +57,10 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
       }
       catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e)
       {
-         throw new RuntimeException(e);
+         LogTools.error("Unable to create an instance of CDRSerializable class: " + clazz.getName());
       }
+
+      return null;
    }
 
    @Override
@@ -85,32 +88,14 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
 
    public void add(T element)
    {
-      if (elements == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (position >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (position == elements.length)
-      {
-         ensureMinCapacity(2 * elements.length);
-      }
+      ensureMinCapacity(position + 1);
 
       elements[position++] = element;
    }
 
    public T add()
    {
-      if (elements == null)
-      {
-         ensureMinCapacity(DEFAULT_INITIAL_CAPACITY);
-      }
-      else if (position == elements.length)
-      {
-         ensureMinCapacity(2 * elements.length);
-      }
+      ensureMinCapacity(position + 1);
 
       if (elements[position] == null)
       {
@@ -118,6 +103,11 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
       }
 
       return elements[position++];
+   }
+
+   public void remove()
+   {
+      position--;
    }
 
    public T get(int index)
@@ -136,13 +126,22 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    @SuppressWarnings("unchecked")
    public void ensureMinCapacity(int desiredCapacity)
    {
-      if (elements == null)
+      if (capacity() < desiredCapacity)
       {
-         elements = (T[]) new CDRSerializable[desiredCapacity];
-      }
-      else if (elements.length < desiredCapacity)
-      {
-         elements = Arrays.copyOf(elements, desiredCapacity);
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+         }
+
+         if (elements == null)
+         {
+            elements = (T[]) new CDRSerializable[desiredCapacity];
+         }
+         else
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * 2), getMaxSize());
+            elements = Arrays.copyOf(elements, desiredCapacity);
+         }
       }
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLObjectSequence.java
@@ -75,7 +75,7 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return position;
    }
@@ -118,7 +118,7 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
 
    public T get(int index)
    {
-      assert index < elements();
+      assert index < size();
 
       return elements[index];
    }
@@ -181,11 +181,11 @@ public class IDLObjectSequence<T extends CDRSerializable> extends IDLSequence<ID
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       // TODO: This could be done better if this has existing elements
       System.arraycopy(other.elements, 0, elements, 0, othersElements);
-      position = other.elements();
+      position = other.size();
    }
 }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -32,12 +32,12 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
    {
       if (maxSize < 0)
       {
-         throw new RuntimeException("IDLSequence maxSize cannot be negative");
+         throw new IllegalArgumentException("IDLSequence maxSize cannot be negative");
       }
 
-      if (!isUnbounded() && (capacity > maxSize))
+      if (capacity > maxSize)
       {
-         throw new RuntimeException("IDLSequence capacity cannot be larger than maxSize");
+         throw new IllegalArgumentException("IDLSequence capacity cannot be larger than maxSize");
       }
 
       this.maxSize = maxSize;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -85,8 +85,8 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     * Ensures the capacity is at least {@code desiredCapacity}.
     *
     * @param desiredCapacity The minimum required capacity.
-    * @implSpec If the current capacity is greater than or equal to {@code capacity}, the capacity need not be changed.
-    *       Otherwise, the capacity should be increased to be grater than or equal to {@code capacity}.
+    * @implSpec If the current capacity is greater than or equal to {@code desiredCapacity}, the capacity need not be changed.
+    *       Otherwise, the capacity should be increased to be grater than or equal to {@code desiredCapacity}.
     *       <p>
     *       Elements should not be added or removed by this method.
     * @return true if the capacity was not needed to be changed or was changed successfully,

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -20,34 +20,39 @@ import us.ihmc.fastddsjava.cdr.CDRSerializable;
 
 public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerializable
 {
-   protected static final int INFINITE_MAX_SIZE = Integer.MAX_VALUE;
-   protected static final int DEFAULT_INITIAL_CAPACITY = 1;
+   public static final int UNBOUNDED_MAX_SIZE = Integer.MAX_VALUE;
+   public static final int DEFAULT_INITIAL_CAPACITY = 1;
 
    /**
-    * The maximum size of the sequence. -1 indicates no maximum size.
+    * The maximum size of the sequence. {@link #UNBOUNDED_MAX_SIZE} indicates the maximum maxSize.
     */
    private final int maxSize;
 
    public IDLSequence(int capacity, int maxSize)
    {
-      this.maxSize = maxSize;
+      if (maxSize < 0)
+      {
+         throw new RuntimeException("IDLSequence maxSize cannot be negative");
+      }
 
       if (!isUnbounded() && (capacity > maxSize))
       {
-         throw new RuntimeException("capacity cannot be larger than maxSize for an IDLSequence");
+         throw new RuntimeException("IDLSequence capacity cannot be larger than maxSize");
       }
+
+      this.maxSize = maxSize;
 
       ensureMinCapacity(capacity);
    }
 
    public IDLSequence()
    {
-      this.maxSize = INFINITE_MAX_SIZE;
+      this.maxSize = UNBOUNDED_MAX_SIZE;
    }
 
    public boolean isUnbounded()
    {
-      return maxSize == INFINITE_MAX_SIZE;
+      return maxSize == UNBOUNDED_MAX_SIZE;
    }
 
    public int getMaxSize()

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -21,7 +21,7 @@ import us.ihmc.fastddsjava.cdr.CDRSerializable;
 public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerializable
 {
    public static final int UNBOUNDED_MAX_SIZE = Integer.MAX_VALUE;
-   public static final int DEFAULT_INITIAL_CAPACITY = 1;
+   public static final int CAPACITY_GROW_SCALAR = 2;
 
    /**
     * The maximum size of the sequence. {@link #UNBOUNDED_MAX_SIZE} indicates the maximum maxSize.
@@ -41,8 +41,6 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
       }
 
       this.maxSize = maxSize;
-
-      ensureMinCapacity(capacity);
    }
 
    public IDLSequence()
@@ -91,8 +89,10 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     *       Otherwise, the capacity should be increased to be grater than or equal to {@code capacity}.
     *       <p>
     *       Elements should not be added or removed by this method.
+    * @return true if the capacity was not needed to be changed or was changed successfully,
+    *          false if the new capacity would exceed {@link #getMaxSize()}
     */
-   public abstract void ensureMinCapacity(int capacity);
+   public abstract boolean ensureMinCapacity(int capacity);
 
    public abstract int elementSizeBytes(int currentAlignment, int i);
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -82,9 +82,9 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
    public abstract void clear();
 
    /**
-    * Ensures the capacity is at least {@code capacity}.
+    * Ensures the capacity is at least {@code desiredCapacity}.
     *
-    * @param capacity The minimum required capacity.
+    * @param desiredCapacity The minimum required capacity.
     * @implSpec If the current capacity is greater than or equal to {@code capacity}, the capacity need not be changed.
     *       Otherwise, the capacity should be increased to be grater than or equal to {@code capacity}.
     *       <p>
@@ -92,7 +92,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     * @return true if the capacity was not needed to be changed or was changed successfully,
     *          false if the new capacity would exceed {@link #getMaxSize()}
     */
-   public abstract boolean ensureMinCapacity(int capacity);
+   public abstract boolean ensureMinCapacity(int desiredCapacity);
 
    public abstract int elementSizeBytes(int currentAlignment, int i);
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -87,7 +87,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     *       <p>
     *       Elements should not be added or removed by this method.
     */
-   protected abstract void ensureMinCapacity(int capacity);
+   public abstract void ensureMinCapacity(int capacity);
 
    public abstract int elementSizeBytes(int currentAlignment, int i);
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLSequence.java
@@ -61,7 +61,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
    /**
     * @return The number of elements in the sequence.
     */
-   public abstract int elements();
+   public abstract int size();
 
    /**
     * @return The capacity of the sequence.
@@ -73,7 +73,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     */
    public int remainingCapacity()
    {
-      return capacity() - elements();
+      return capacity() - size();
    }
 
    /**
@@ -110,7 +110,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
     * Sets this sequence to {@code other}.
     *
     * @param other The sequence to set from.
-    * @implSpec {@link #elements()} of this sequence will return the same values as {@code other} after calling this method.
+    * @implSpec {@link #size()} of this sequence will return the same values as {@code other} after calling this method.
     */
    public abstract void set(T other);
 
@@ -121,7 +121,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
 
       currentAlignment += 4 + CDRBuffer.alignment(currentAlignment, 4); // Length header
 
-      for (int i = 0; i < elements(); i++)
+      for (int i = 0; i < size(); i++)
       {
          int elementSizeBytes = elementSizeBytes(currentAlignment, i);
 
@@ -134,7 +134,7 @@ public abstract class IDLSequence<T extends IDLSequence<T>> implements CDRSerial
    @Override
    public void serialize(CDRBuffer buffer)
    {
-      int elements = elements();
+      int elements = size();
 
       buffer.writeInt(elements);
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
@@ -16,6 +16,7 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.nio.ShortBuffer;
 
@@ -30,7 +31,7 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
 
    public IDLShortSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
    public IDLShortSequence()
@@ -69,31 +70,6 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
       }
    }
 
-   public void add(short element)
-   {
-      if (buffer == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (buffer.position() >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (buffer.position() == buffer.capacity())
-      {
-         ensureMinCapacity(2 * buffer.capacity());
-      }
-
-      buffer.put(element);
-   }
-
-   public short get(int index)
-   {
-      assert index < elements();
-
-      return buffer.get(index);
-   }
-
    /**
     * Get the backing heap {@link ShortBuffer} holding all short values in the sequence.
     * Use this for efficient copy operations, however ensure the buffer is initialized and
@@ -111,13 +87,24 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
    {
       if (capacity() < desiredCapacity)
       {
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (buffer != null)
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
+         }
+
          ShortBuffer newBuffer = ShortBuffer.allocate(desiredCapacity);
 
-         int currentElements = elements();
-         if (currentElements != 0)
+         if (buffer != null)
          {
-            newBuffer.put(0, buffer, 0, currentElements);
-            newBuffer.position(currentElements);
+            newBuffer.put(0, buffer, 0, buffer.position());
+            newBuffer.position(buffer.position());
          }
 
          buffer = newBuffer;

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
@@ -57,7 +57,7 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return buffer.position();
    }
@@ -124,7 +124,7 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       buffer.put(0, other.buffer, 0, othersElements);

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
@@ -16,66 +16,40 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.nio.ShortBuffer;
 
 public class IDLShortSequence extends IDLSequence<IDLShortSequence>
 {
+   private static final ShortBuffer EMPTY_BUFFER = ShortBuffer.allocate(0);
+
    private ShortBuffer buffer;
 
-   public IDLShortSequence(int capacity, int maxSize)
+   public IDLShortSequence()
    {
-      super(capacity, maxSize);
+      buffer = EMPTY_BUFFER;
    }
 
    public IDLShortSequence(int capacity)
    {
-      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+      this(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
    }
 
-   public IDLShortSequence()
+   public IDLShortSequence(int capacity, int maxSize)
    {
+      super(capacity, maxSize);
 
-   }
+      buffer = EMPTY_BUFFER;
 
-   @Override
-   public int elements()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.position();
-   }
-
-   @Override
-   public int capacity()
-   {
-      if (buffer == null)
-      {
-         return 0;
-      }
-
-      return buffer.capacity();
-   }
-
-   @Override
-   public void clear()
-   {
-      if (buffer != null)
-      {
-         buffer.clear();
-      }
+      ensureMinCapacity(capacity);
    }
 
    /**
     * Get the backing heap {@link ShortBuffer} holding all short values in the sequence.
-    * Use this for efficient copy operations, however ensure the buffer is initialized and
-    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    * Use this for efficient copy operations, however ensure the buffer is the correct capacity
+    * first with {@link #ensureMinCapacity(int)}!
     *
-    * @return the buffer of short values, may be null
+    * @return the buffer of short values
     */
    public ShortBuffer getBuffer()
    {
@@ -83,32 +57,48 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
    }
 
    @Override
-   public void ensureMinCapacity(int desiredCapacity)
+   public int elements()
    {
-      if (capacity() < desiredCapacity)
+      return buffer.position();
+   }
+
+   @Override
+   public int capacity()
+   {
+      return buffer.capacity();
+   }
+
+   @Override
+   public void clear()
+   {
+      buffer.clear();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public boolean ensureMinCapacity(int desiredCapacity)
+   {
+      if (buffer.capacity() < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
+            return false;
          }
-
-         if (buffer != null)
+         else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, buffer.capacity() * 2), getMaxSize());
-         }
-
-         ShortBuffer newBuffer = ShortBuffer.allocate(desiredCapacity);
-
-         if (buffer != null)
-         {
+            ShortBuffer newBuffer = ShortBuffer.allocate(desiredCapacity);
             newBuffer.put(0, buffer, 0, buffer.position());
             newBuffer.position(buffer.position());
-         }
 
-         buffer = newBuffer;
+            buffer = newBuffer;
+         }
       }
+
+      return true;
    }
 
    @Override
@@ -120,16 +110,12 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
    @Override
    public void readElement(CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       buffer.put(cdrBuffer.readShort());
    }
 
    @Override
    public void writeElement(int i, CDRBuffer cdrBuffer)
    {
-      assert buffer != null;
-
       cdrBuffer.writeShort(buffer.get(i));
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
@@ -94,13 +94,20 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
       return buffer.get(index);
    }
 
+   /**
+    * Get the backing heap {@link ShortBuffer} holding all short values in the sequence.
+    * Use this for efficient copy operations, however ensure the buffer is initialized and
+    * of the correct capacity first with {@link #ensureMinCapacity(int)}!
+    *
+    * @return the buffer of short values, may be null
+    */
    public ShortBuffer getBufferUnsafe()
    {
       return buffer;
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (capacity() < desiredCapacity)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLShortSequence.java
@@ -77,7 +77,7 @@ public class IDLShortSequence extends IDLSequence<IDLShortSequence>
     *
     * @return the buffer of short values, may be null
     */
-   public ShortBuffer getBufferUnsafe()
+   public ShortBuffer getBuffer()
    {
       return buffer;
    }

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -136,7 +136,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    }
 
    @Override
-   protected void ensureMinCapacity(int desiredCapacity)
+   public void ensureMinCapacity(int desiredCapacity)
    {
       if (elements == null)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -16,12 +16,13 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
+import us.ihmc.log.LogTools;
 
 import java.util.Arrays;
 
 public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 {
-   private static final int DEFAULT_STRING_CAPACITY = 16;
+   private static final int DEFAULT_STRING_LENGTH = 16;
 
    protected StringBuilder[] elements;
    protected int position;
@@ -35,7 +36,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    public IDLStringSequence(int capacity)
    {
-      super(capacity, IDLSequence.INFINITE_MAX_SIZE);
+      super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
       defaultStringLength = -1;
    }
 
@@ -74,18 +75,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    public void add(StringBuilder element)
    {
-      if (elements == null)
-      {
-         ensureMinCapacity(Math.min(getMaxSize(), DEFAULT_INITIAL_CAPACITY));
-      }
-      else if (!isUnbounded() && (position >= getMaxSize()))
-      {
-         throw new RuntimeException("Cannot add element to the sequence, reached upper bound");
-      }
-      else if (position == elements.length)
-      {
-         ensureMinCapacity(2 * elements.length);
-      }
+      ensureMinCapacity(position + 1);
 
       elements[position++] = element;
    }
@@ -97,18 +87,11 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    public StringBuilder add(int stringLength)
    {
-      if (elements == null)
-      {
-         ensureMinCapacity(DEFAULT_INITIAL_CAPACITY);
-      }
-      else if (position == elements.length)
-      {
-         ensureMinCapacity(2 * elements.length);
-      }
+      ensureMinCapacity(position + 1);
 
       if (elements[position] == null)
       {
-         elements[position] = new StringBuilder(stringLength > 0 ? stringLength : DEFAULT_STRING_CAPACITY);
+         elements[position] = new StringBuilder(stringLength > 0 ? stringLength : DEFAULT_STRING_LENGTH);
       }
       else if (stringLength > 0)
       {
@@ -116,6 +99,11 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
       }
 
       return elements[position++];
+   }
+
+   public void remove()
+   {
+      position--;
    }
 
    public StringBuilder get(int index)
@@ -136,15 +124,27 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public void ensureMinCapacity(int desiredCapacity)
    {
-      if (elements == null)
+      if (capacity() < desiredCapacity)
       {
-         elements = new StringBuilder[desiredCapacity];
-      }
-      else if (elements.length < desiredCapacity)
-      {
-         elements = Arrays.copyOf(elements, desiredCapacity);
+         if (desiredCapacity > getMaxSize())
+         {
+            LogTools.error("Cannot add element to the sequence, reached upper bound");
+
+            return;
+         }
+
+         if (elements == null)
+         {
+            elements = new StringBuilder[desiredCapacity];
+         }
+         else
+         {
+            desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * 2), getMaxSize());
+            elements = Arrays.copyOf(elements, desiredCapacity);
+         }
       }
    }
 

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -55,7 +55,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    }
 
    @Override
-   public int elements()
+   public int size()
    {
       return position;
    }
@@ -168,7 +168,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    {
       clear();
 
-      int othersElements = other.elements();
+      int othersElements = other.size();
       ensureMinCapacity(othersElements);
 
       for (int i = 0; i < othersElements; ++i)

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 
 public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 {
-   private static final int DEFAULT_STRING_LENGTH = 16;
+   private static final int DEFAULT_MAX_STRING_LENGTH = 16;
 
    protected StringBuilder[] elements;
    protected int position;
@@ -91,7 +91,7 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
       if (elements[position] == null)
       {
-         elements[position] = new StringBuilder(stringLength > 0 ? stringLength : DEFAULT_STRING_LENGTH);
+         elements[position] = new StringBuilder(stringLength > 0 ? stringLength : DEFAULT_MAX_STRING_LENGTH);
       }
       else if (stringLength > 0)
       {

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLStringSequence.java
@@ -16,33 +16,42 @@
 package us.ihmc.fastddsjava.cdr.idl;
 
 import us.ihmc.fastddsjava.cdr.CDRBuffer;
-import us.ihmc.log.LogTools;
 
 import java.util.Arrays;
 
 public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 {
+   private static final StringBuilder[] EMPTY_ARRAY = new StringBuilder[0];
    private static final int DEFAULT_MAX_STRING_LENGTH = 16;
 
    protected StringBuilder[] elements;
    protected int position;
    private final int defaultStringLength;
 
-   public IDLStringSequence(int capacity, int maxSize, int defaultStringLength)
+   public IDLStringSequence()
    {
-      super(capacity, maxSize);
-      this.defaultStringLength = defaultStringLength;
+      elements = EMPTY_ARRAY;
+      defaultStringLength = -1;
    }
 
    public IDLStringSequence(int capacity)
    {
       super(capacity, IDLSequence.UNBOUNDED_MAX_SIZE);
+
+      elements = EMPTY_ARRAY;
       defaultStringLength = -1;
+
+      ensureMinCapacity(capacity);
    }
 
-   public IDLStringSequence()
+   public IDLStringSequence(int capacity, int maxSize, int defaultStringLength)
    {
-      defaultStringLength = -1;
+      super(capacity, maxSize);
+
+      elements = EMPTY_ARRAY;
+      this.defaultStringLength = defaultStringLength;
+
+      ensureMinCapacity(capacity);
    }
 
    @Override
@@ -54,11 +63,6 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    @Override
    public int capacity()
    {
-      if (elements == null)
-      {
-         return 0;
-      }
-
       return elements.length;
    }
 
@@ -108,8 +112,6 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
 
    public StringBuilder get(int index)
    {
-      assert index < elements();
-
       return elements[index];
    }
 
@@ -118,42 +120,32 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
       return get(index).toString();
    }
 
-   public StringBuilder[] getArrayUnsafe()
-   {
-      return elements;
-   }
-
+   /**
+    * {@inheritDoc}
+    */
    @Override
-   @SuppressWarnings("unchecked")
-   public void ensureMinCapacity(int desiredCapacity)
+   public boolean ensureMinCapacity(int desiredCapacity)
    {
-      if (capacity() < desiredCapacity)
+      if (elements.length < desiredCapacity)
       {
+         desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * CAPACITY_GROW_SCALAR), getMaxSize());
+
          if (desiredCapacity > getMaxSize())
          {
-            LogTools.error("Cannot add element to the sequence, reached upper bound");
-
-            return;
-         }
-
-         if (elements == null)
-         {
-            elements = new StringBuilder[desiredCapacity];
+            return false;
          }
          else
          {
-            desiredCapacity = Math.min(Math.max(desiredCapacity, elements.length * 2), getMaxSize());
             elements = Arrays.copyOf(elements, desiredCapacity);
          }
       }
+
+      return true;
    }
 
    @Override
    public int elementSizeBytes(int currentAlignment, int i)
    {
-      assert elements != null;
-      assert i < elements();
-
       // We treat each character as 1 byte (8 bits) in a standard string
       return elements[i].length() + CDRBuffer.alignment(currentAlignment, elements[i].length());
    }
@@ -161,9 +153,6 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    @Override
    public void readElement(CDRBuffer buffer)
    {
-      assert elements != null;
-      assert position < elements.length;
-
       StringBuilder element = elements[position++];
       buffer.readString(element);
    }
@@ -171,17 +160,12 @@ public class IDLStringSequence extends IDLSequence<IDLStringSequence>
    @Override
    public void writeElement(int i, CDRBuffer buffer)
    {
-      assert elements != null;
-      assert i < elements();
-
       buffer.writeString(elements[i]);
    }
 
    @Override
    public void set(IDLStringSequence other)
    {
-      assert other.elements != null;
-
       clear();
 
       int othersElements = other.elements();

--- a/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLWStringSequence.java
+++ b/src/main/java/us/ihmc/fastddsjava/cdr/idl/IDLWStringSequence.java
@@ -19,9 +19,9 @@ import us.ihmc.fastddsjava.cdr.CDRBuffer;
 
 public class IDLWStringSequence extends IDLStringSequence
 {
-   public IDLWStringSequence(int capacity, int maxSize, int defaultStringLength)
+   public IDLWStringSequence()
    {
-      super(capacity, maxSize, defaultStringLength);
+      super();
    }
 
    public IDLWStringSequence(int maxSize)
@@ -29,25 +29,20 @@ public class IDLWStringSequence extends IDLStringSequence
       super(maxSize);
    }
 
-   public IDLWStringSequence()
+   public IDLWStringSequence(int capacity, int maxSize, int defaultStringLength)
    {
+      super(capacity, maxSize, defaultStringLength);
    }
 
    @Override
    public int elementSizeBytes(int currentAlignment, int i)
    {
-      assert elements != null;
-      assert i < elements();
-
       return (elements[i].length() * 4) + CDRBuffer.alignment(currentAlignment, elements[i].length() * 4); // 4 bytes per character
    }
 
    @Override
    public void readElement(CDRBuffer buffer)
    {
-      assert elements != null;
-      assert position < elements.length;
-
       StringBuilder element = elements[position++];
       buffer.readWString(element);
    }
@@ -55,9 +50,6 @@ public class IDLWStringSequence extends IDLStringSequence
    @Override
    public void writeElement(int i, CDRBuffer buffer)
    {
-      assert elements != null;
-      assert i < elements();
-
       buffer.writeWString(elements[i]);
    }
 }

--- a/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
+++ b/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
@@ -32,7 +32,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.getBufferUnsafe().put((byte) i);
+         sequence.getBuffer().put((byte) i);
       }
 
       // It should have initialCapacity elements
@@ -46,7 +46,7 @@ public class IDLSequenceTest
 
       // Add one more element (going past the initial capacity)
       sequence.ensureMinCapacity(initialCapacity + 1);
-      sequence.getBufferUnsafe().put((byte) initialCapacity);
+      sequence.getBuffer().put((byte) initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -57,7 +57,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((byte) i, sequence.getBufferUnsafe().get(i));
+         assertEquals((byte) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -77,7 +77,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
 
       // Clear the original sequence
@@ -115,7 +115,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.getBufferUnsafe().put((char) i);
+         sequence.getBuffer().put((char) i);
       }
 
       // It should have initialCapacity elements
@@ -129,7 +129,7 @@ public class IDLSequenceTest
 
       // Add one more element (going past the initial capacity)
       sequence.ensureMinCapacity(initialCapacity + 1);
-      sequence.getBufferUnsafe().put((char) initialCapacity);
+      sequence.getBuffer().put((char) initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -140,7 +140,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((byte) i, sequence.getBufferUnsafe().get(i));
+         assertEquals((byte) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -160,7 +160,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
 
       // Clear the original sequence
@@ -198,7 +198,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.getBufferUnsafe().put(i);
+         sequence.getBuffer().put(i);
       }
 
       // It should have initialCapacity elements
@@ -212,7 +212,7 @@ public class IDLSequenceTest
 
       // Add one more element (going past the initial capacity)
       sequence.ensureMinCapacity(initialCapacity + 1);
-      sequence.getBufferUnsafe().put(initialCapacity);
+      sequence.getBuffer().put(initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -223,7 +223,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals(i, sequence.getBufferUnsafe().get(i));
+         assertEquals(i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -243,7 +243,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
 
       // Clear the original sequence
@@ -281,7 +281,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.getBufferUnsafe().put(i);
+         sequence.getBuffer().put(i);
       }
 
       // It should have initialCapacity elements
@@ -295,7 +295,7 @@ public class IDLSequenceTest
 
       // Add one more element (going past the initial capacity)
       sequence.ensureMinCapacity(initialCapacity + 1);
-      sequence.getBufferUnsafe().put(initialCapacity);
+      sequence.getBuffer().put(initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -306,7 +306,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((float) i, sequence.getBufferUnsafe().get(i));
+         assertEquals((float) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -326,7 +326,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
 
       // Clear the original sequence
@@ -448,7 +448,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.getBufferUnsafe().put((short) i);
+         sequence.getBuffer().put((short) i);
       }
 
       // It should have initialCapacity elements
@@ -459,7 +459,7 @@ public class IDLSequenceTest
 
       // Add one more element (going past the initial capacity)
       sequence.ensureMinCapacity(initialCapacity + 1);
-      sequence.getBufferUnsafe().put((short) initialCapacity);
+      sequence.getBuffer().put((short) initialCapacity);
 
       // Make sure elementSizeBytes is correct
       assertEquals(Short.BYTES, sequence.elementSizeBytes(0, 0));
@@ -473,7 +473,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((short) i, sequence.getBufferUnsafe().get(i));
+         assertEquals((short) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -493,7 +493,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
 
       // Clear the original sequence

--- a/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
+++ b/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
@@ -1,6 +1,7 @@
 package us.ihmc.fastddsjava;
 
 import org.junit.jupiter.api.Test;
+import us.ihmc.fastddsjava.cdr.idl.IDLBoolSequence;
 import us.ihmc.fastddsjava.cdr.idl.IDLByteSequence;
 import us.ihmc.fastddsjava.cdr.idl.IDLCharSequence;
 import us.ihmc.fastddsjava.cdr.idl.IDLDoubleSequence;
@@ -16,6 +17,90 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class IDLSequenceTest
 {
+   @Test
+   public void testIDLBoolSequence()
+   {
+      final int initialCapacity = 8;
+
+      IDLBoolSequence sequence = new IDLBoolSequence(initialCapacity);
+
+      // The sequence should have no elements
+      assertEquals(0, sequence.elements());
+
+      // It's capacity should be the requested initial capacity
+      assertEquals(initialCapacity, sequence.capacity());
+
+      // Add initialCapacity number of elements to the sequence
+      for (int i = 0; i < initialCapacity; ++i)
+      {
+         sequence.getBuffer().put(i % 2 == 0);
+      }
+
+      // It should have initialCapacity elements
+      assertEquals(initialCapacity, sequence.elements());
+
+      // The capacity should not have changed
+      assertEquals(initialCapacity, sequence.capacity());
+
+      // Make sure elementSizeBytes is correct
+      int booleanSizeBytes = 1;
+      assertEquals(booleanSizeBytes, sequence.elementSizeBytes(0, 0));
+
+      // Add one more element (going past the initial capacity)
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBuffer().put(true);
+
+      // The element should have been added
+      assertEquals(initialCapacity + 1, sequence.elements());
+
+      // Current capacity should be greater than the initial capacity
+      assertTrue(sequence.capacity() > initialCapacity);
+
+      // Make sure the elements we added are stored correctly
+      for (int i = 0; i < sequence.elements(); ++i)
+      {
+         assertEquals(i % 2 == 0, sequence.getBuffer().get(i));
+      }
+
+      int originalCapacity = sequence.capacity();
+      int originalElements = sequence.elements();
+
+      // Make a copy of the sequence
+      IDLBoolSequence copySequence = new IDLBoolSequence();
+      copySequence.set(sequence);
+
+      // Make sure the original wasn't affected by the copy
+      assertEquals(originalCapacity, sequence.capacity());
+      assertEquals(originalElements, sequence.elements());
+
+      // The copy should have same number of elements as the original
+      assertEquals(copySequence.elements(), sequence.elements());
+
+      // Make sure elements are equal in the copy
+      for (int i = 0; i < copySequence.elements(); ++i)
+      {
+         assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
+      }
+
+      // Clear the original sequence
+      sequence.clear();
+
+      // Make sure it has no elements, but capacity should not be affected
+      assertEquals(0, sequence.elements());
+      assertEquals(originalCapacity, sequence.capacity());
+
+      // Make sure the copy wasn't affected by changes to the original
+      assertEquals(originalElements, copySequence.elements());
+
+      // Create a new sequence with no initial buffer
+      IDLByteSequence emptySequence = new IDLByteSequence();
+
+      // Ensure methods work on empty sequences
+      assertEquals(0, emptySequence.capacity());
+      assertEquals(0, emptySequence.elements());
+      assertDoesNotThrow(emptySequence::clear);
+   }
+
    @Test
    public void testIDLByteSequence()
    {

--- a/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
+++ b/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
@@ -25,7 +25,7 @@ public class IDLSequenceTest
       IDLBoolSequence sequence = new IDLBoolSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -37,7 +37,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -51,19 +51,19 @@ public class IDLSequenceTest
       sequence.getBuffer().put(true);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals(i % 2 == 0, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLBoolSequence copySequence = new IDLBoolSequence();
@@ -71,13 +71,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -86,18 +86,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLByteSequence emptySequence = new IDLByteSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -109,7 +109,7 @@ public class IDLSequenceTest
       IDLByteSequence sequence = new IDLByteSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -121,7 +121,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -134,19 +134,19 @@ public class IDLSequenceTest
       sequence.getBuffer().put((byte) initialCapacity);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals((byte) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLByteSequence copySequence = new IDLByteSequence();
@@ -154,13 +154,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -169,18 +169,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLByteSequence emptySequence = new IDLByteSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -192,7 +192,7 @@ public class IDLSequenceTest
       IDLCharSequence sequence = new IDLCharSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -204,7 +204,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -217,19 +217,19 @@ public class IDLSequenceTest
       sequence.getBuffer().put((char) initialCapacity);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals((byte) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLCharSequence copySequence = new IDLCharSequence();
@@ -237,13 +237,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -252,18 +252,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLCharSequence emptySequence = new IDLCharSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -275,7 +275,7 @@ public class IDLSequenceTest
       IDLDoubleSequence sequence = new IDLDoubleSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -287,7 +287,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -300,19 +300,19 @@ public class IDLSequenceTest
       sequence.getBuffer().put(initialCapacity);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals(i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLDoubleSequence copySequence = new IDLDoubleSequence();
@@ -320,13 +320,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -335,18 +335,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLDoubleSequence emptySequence = new IDLDoubleSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -358,7 +358,7 @@ public class IDLSequenceTest
       IDLFloatSequence sequence = new IDLFloatSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -370,7 +370,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -383,19 +383,19 @@ public class IDLSequenceTest
       sequence.getBuffer().put(initialCapacity);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals((float) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLFloatSequence copySequence = new IDLFloatSequence();
@@ -403,13 +403,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -418,18 +418,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLFloatSequence emptySequence = new IDLFloatSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -441,7 +441,7 @@ public class IDLSequenceTest
       IDLObjectSequence<TestIDLMsg> sequence = new IDLObjectSequence<>(initialCapacity, TestIDLMsg.class);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -453,7 +453,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -467,19 +467,19 @@ public class IDLSequenceTest
       sequence.add(newElement);
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals(i % 2 == 0, sequence.get(i).getData());
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLObjectSequence<TestIDLMsg> copySequence = new IDLObjectSequence<>(TestIDLMsg.class);
@@ -487,13 +487,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.get(i), sequence.get(i));
       }
@@ -502,18 +502,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLObjectSequence<TestIDLMsg> emptySequence = new IDLObjectSequence<>(TestIDLMsg.class);
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -525,7 +525,7 @@ public class IDLSequenceTest
       IDLShortSequence sequence = new IDLShortSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -537,7 +537,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -550,19 +550,19 @@ public class IDLSequenceTest
       assertEquals(Short.BYTES, sequence.elementSizeBytes(0, 0));
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals((short) i, sequence.getBuffer().get(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLShortSequence copySequence = new IDLShortSequence();
@@ -570,13 +570,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getBuffer().get(i), sequence.getBuffer().get(i));
       }
@@ -585,18 +585,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLShortSequence emptySequence = new IDLShortSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -608,7 +608,7 @@ public class IDLSequenceTest
       IDLStringSequence sequence = new IDLStringSequence(initialCapacity);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -620,7 +620,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -632,19 +632,19 @@ public class IDLSequenceTest
       assertEquals(1, sequence.elementSizeBytes(0, 0));
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals(String.valueOf(i), sequence.getAsString(i));
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLStringSequence copySequence = new IDLStringSequence();
@@ -652,13 +652,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getAsString(i), sequence.getAsString(i));
       }
@@ -667,18 +667,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLStringSequence emptySequence = new IDLStringSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 
@@ -693,7 +693,7 @@ public class IDLSequenceTest
       IDLWStringSequence sequence = new IDLWStringSequence(initialCapacity, maxSize, defaultStringLength);
 
       // The sequence should have no elements
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
 
       // It's capacity should be the requested initial capacity
       assertEquals(initialCapacity, sequence.capacity());
@@ -709,7 +709,7 @@ public class IDLSequenceTest
       }
 
       // It should have initialCapacity elements
-      assertEquals(initialCapacity, sequence.elements());
+      assertEquals(initialCapacity, sequence.size());
 
       // The capacity should not have changed
       assertEquals(initialCapacity, sequence.capacity());
@@ -721,21 +721,21 @@ public class IDLSequenceTest
       assertEquals(8, sequence.elementSizeBytes(0, 0));
 
       // The element should have been added
-      assertEquals(initialCapacity + 1, sequence.elements());
+      assertEquals(initialCapacity + 1, sequence.size());
 
       // Current capacity should be greater than the initial capacity
       assertTrue(sequence.capacity() > initialCapacity);
 
       // Make sure the elements we added are stored correctly
       codepoint = codepointStart;
-      for (int i = 0; i < sequence.elements(); ++i)
+      for (int i = 0; i < sequence.size(); ++i)
       {
          assertEquals(new String(Character.toChars(codepoint)), sequence.getAsString(i));
          codepoint++;
       }
 
       int originalCapacity = sequence.capacity();
-      int originalElements = sequence.elements();
+      int originalElements = sequence.size();
 
       // Make a copy of the sequence
       IDLWStringSequence copySequence = new IDLWStringSequence();
@@ -743,13 +743,13 @@ public class IDLSequenceTest
 
       // Make sure the original wasn't affected by the copy
       assertEquals(originalCapacity, sequence.capacity());
-      assertEquals(originalElements, sequence.elements());
+      assertEquals(originalElements, sequence.size());
 
       // The copy should have same number of elements as the original
-      assertEquals(copySequence.elements(), sequence.elements());
+      assertEquals(copySequence.size(), sequence.size());
 
       // Make sure elements are equal in the copy
-      for (int i = 0; i < copySequence.elements(); ++i)
+      for (int i = 0; i < copySequence.size(); ++i)
       {
          assertEquals(copySequence.getAsString(i), sequence.getAsString(i));
       }
@@ -758,18 +758,18 @@ public class IDLSequenceTest
       sequence.clear();
 
       // Make sure it has no elements, but capacity should not be affected
-      assertEquals(0, sequence.elements());
+      assertEquals(0, sequence.size());
       assertEquals(originalCapacity, sequence.capacity());
 
       // Make sure the copy wasn't affected by changes to the original
-      assertEquals(originalElements, copySequence.elements());
+      assertEquals(originalElements, copySequence.size());
 
       // Create a new sequence with no initial buffer
       IDLWStringSequence emptySequence = new IDLWStringSequence();
 
       // Ensure methods work on empty sequences
       assertEquals(0, emptySequence.capacity());
-      assertEquals(0, emptySequence.elements());
+      assertEquals(0, emptySequence.size());
       assertDoesNotThrow(emptySequence::clear);
    }
 }

--- a/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
+++ b/src/test/java/us/ihmc/fastddsjava/IDLSequenceTest.java
@@ -32,7 +32,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.add((byte) i);
+         sequence.getBufferUnsafe().put((byte) i);
       }
 
       // It should have initialCapacity elements
@@ -45,7 +45,8 @@ public class IDLSequenceTest
       assertEquals(Byte.BYTES, sequence.elementSizeBytes(0, 0));
 
       // Add one more element (going past the initial capacity)
-      sequence.add((byte) initialCapacity);
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBufferUnsafe().put((byte) initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -56,7 +57,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((byte) i, sequence.get(i));
+         assertEquals((byte) i, sequence.getBufferUnsafe().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -76,7 +77,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.get(i), sequence.get(i));
+         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
       }
 
       // Clear the original sequence
@@ -114,7 +115,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.add((char) i);
+         sequence.getBufferUnsafe().put((char) i);
       }
 
       // It should have initialCapacity elements
@@ -127,7 +128,8 @@ public class IDLSequenceTest
       assertEquals(Byte.BYTES, sequence.elementSizeBytes(0, 0));
 
       // Add one more element (going past the initial capacity)
-      sequence.add((char) initialCapacity);
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBufferUnsafe().put((char) initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -138,7 +140,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((byte) i, sequence.get(i));
+         assertEquals((byte) i, sequence.getBufferUnsafe().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -158,7 +160,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.get(i), sequence.get(i));
+         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
       }
 
       // Clear the original sequence
@@ -196,7 +198,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.add(i);
+         sequence.getBufferUnsafe().put(i);
       }
 
       // It should have initialCapacity elements
@@ -209,7 +211,8 @@ public class IDLSequenceTest
       assertEquals(Double.BYTES, sequence.elementSizeBytes(0, 0));
 
       // Add one more element (going past the initial capacity)
-      sequence.add(initialCapacity);
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBufferUnsafe().put(initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -220,7 +223,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals(i, sequence.get(i));
+         assertEquals(i, sequence.getBufferUnsafe().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -240,7 +243,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.get(i), sequence.get(i));
+         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
       }
 
       // Clear the original sequence
@@ -278,7 +281,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.add(i);
+         sequence.getBufferUnsafe().put(i);
       }
 
       // It should have initialCapacity elements
@@ -291,7 +294,8 @@ public class IDLSequenceTest
       assertEquals(Float.BYTES, sequence.elementSizeBytes(0, 0));
 
       // Add one more element (going past the initial capacity)
-      sequence.add(initialCapacity);
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBufferUnsafe().put(initialCapacity);
 
       // The element should have been added
       assertEquals(initialCapacity + 1, sequence.elements());
@@ -302,7 +306,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((float) i, sequence.get(i));
+         assertEquals((float) i, sequence.getBufferUnsafe().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -322,7 +326,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.get(i), sequence.get(i));
+         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
       }
 
       // Clear the original sequence
@@ -444,7 +448,7 @@ public class IDLSequenceTest
       // Add initialCapacity number of elements to the sequence
       for (int i = 0; i < initialCapacity; ++i)
       {
-         sequence.add((short) i);
+         sequence.getBufferUnsafe().put((short) i);
       }
 
       // It should have initialCapacity elements
@@ -454,7 +458,8 @@ public class IDLSequenceTest
       assertEquals(initialCapacity, sequence.capacity());
 
       // Add one more element (going past the initial capacity)
-      sequence.add((short) initialCapacity);
+      sequence.ensureMinCapacity(initialCapacity + 1);
+      sequence.getBufferUnsafe().put((short) initialCapacity);
 
       // Make sure elementSizeBytes is correct
       assertEquals(Short.BYTES, sequence.elementSizeBytes(0, 0));
@@ -468,7 +473,7 @@ public class IDLSequenceTest
       // Make sure the elements we added are stored correctly
       for (int i = 0; i < sequence.elements(); ++i)
       {
-         assertEquals((short) i, sequence.get(i));
+         assertEquals((short) i, sequence.getBufferUnsafe().get(i));
       }
 
       int originalCapacity = sequence.capacity();
@@ -488,7 +493,7 @@ public class IDLSequenceTest
       // Make sure elements are equal in the copy
       for (int i = 0; i < copySequence.elements(); ++i)
       {
-         assertEquals(copySequence.get(i), sequence.get(i));
+         assertEquals(copySequence.getBufferUnsafe().get(i), sequence.getBufferUnsafe().get(i));
       }
 
       // Clear the original sequence


### PR DESCRIPTION
Observe this if-else block in the opencv webcam example project for why the ensureMinCapacity should be exposed: https://github.com/ihmcrobotics/jros2/blob/develop/examples/ros2-opencv-webcam/src/main/java/us/ihmc/WebcamPublisher.java#L33-L48

The example now becomes:
```
if (frameCount == 0)
{
   msg.getEncoding().append("bgr8");
   msg.setWidth(frame.imageWidth);
   msg.setHeight(frame.imageHeight);
   msg.getData().ensureMinCapacity(frame.imageWidth * frame.imageHeight * frame.imageChannels);
}

msg.getData().getBufferUnsafe().rewind();
msg.getData().getBufferUnsafe().put(frameBuffer);
```